### PR TITLE
Use proper decode from json function on WebSocketTransport

### DIFF
--- a/acp-ktor/src/commonMain/kotlin/com/agentclientprotocol/transport/WebSocketTransport.kt
+++ b/acp-ktor/src/commonMain/kotlin/com/agentclientprotocol/transport/WebSocketTransport.kt
@@ -1,6 +1,7 @@
 package com.agentclientprotocol.transport
 
 import com.agentclientprotocol.rpc.ACPJson
+import com.agentclientprotocol.rpc.decodeJsonRpcMessage
 import com.agentclientprotocol.rpc.JsonRpcMessage
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.websocket.*
@@ -59,7 +60,7 @@ public class WebSocketTransport(private val parentScope: CoroutineScope, private
                         is Frame.Text -> {
                             val text = message.readText()
                             val decodedMessage = try {
-                                ACPJson.decodeFromString<JsonRpcMessage>(text)
+                                decodeJsonRpcMessage(text)
                             } catch (e: SerializationException) {
                                 logger.trace(e) { "Failed to deserialize message: '$text'" }
                                 fireError(e)


### PR DESCRIPTION
Hi! I was experimenting with `WebSocketTransport` and I got decoding errors, which was weird because `StdioTransport` worked  out fine. After a little digging, I saw that `WebSocketTransport` calls `ACPJson.decodeFromString` directly instead of `decodeJsonRpcMessage` like `StdioTransport` does, which handles the polymorphism.

The PR fixed my issue, so I figured to bring this upstream. I am unsure if there's a proper reason to not use `decodeJsonRpcMessage` here, so apologies if this doesn't make sense!