### PR TITLE
Generate LIB_VERSION constants in unique packages

### DIFF
--- a/acp-ktor-client/api/acp-ktor-client.api
+++ b/acp-ktor-client/api/acp-ktor-client.api
@@ -1,4 +1,4 @@
-public final class com/agentclientprotocol/LibVersionKt {
+public final class com/agentclientprotocol/acpktorclient/LibVersionKt {
 	public static final field LIB_VERSION Ljava/lang/String;
 }
 

--- a/acp-ktor-server/api/acp-ktor-server.api
+++ b/acp-ktor-server/api/acp-ktor-server.api
@@ -1,4 +1,4 @@
-public final class com/agentclientprotocol/LibVersionKt {
+public final class com/agentclientprotocol/acpktorserver/LibVersionKt {
 	public static final field LIB_VERSION Ljava/lang/String;
 }
 

--- a/acp-ktor/api/acp-ktor.api
+++ b/acp-ktor/api/acp-ktor.api
@@ -1,4 +1,4 @@
-public final class com/agentclientprotocol/LibVersionKt {
+public final class com/agentclientprotocol/acpktor/LibVersionKt {
 	public static final field LIB_VERSION Ljava/lang/String;
 }
 

--- a/acp-model/api/acp-model.api
+++ b/acp-model/api/acp-model.api
@@ -1,4 +1,4 @@
-public final class com/agentclientprotocol/LibVersionKt {
+public final class com/agentclientprotocol/acpmodel/LibVersionKt {
 	public static final field LIB_VERSION Ljava/lang/String;
 }
 

--- a/acp/api/acp.api
+++ b/acp/api/acp.api
@@ -1,4 +1,4 @@
-public final class com/agentclientprotocol/LibVersionKt {
+public final class com/agentclientprotocol/acp/LibVersionKt {
 	public static final field LIB_VERSION Ljava/lang/String;
 }
 

--- a/buildSrc/src/main/kotlin/acp.multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/acp.multiplatform.gradle.kts
@@ -10,15 +10,17 @@ plugins {
 val generateLibVersion by tasks.registering {
     val outputDir = layout.buildDirectory.dir("generated-sources/libVersion")
     outputs.dir(outputDir)
+    val packageName = project.name.replace("-", "")
+    val versionString = project.version
 
     doLast {
-        val sourceFile = outputDir.get().file("io/agentclientprotocol/kotlin/LibVersion.kt").asFile
+        val sourceFile = outputDir.get().file("com/agentclientprotocol/$packageName/LibVersion.kt").asFile
         sourceFile.parentFile.mkdirs()
         sourceFile.writeText(
             """
-            package com.agentclientprotocol
+            package com.agentclientprotocol.$packageName
 
-            public const val LIB_VERSION: String = "${project.version}"
+            public const val LIB_VERSION: String = "$versionString"
             
             """.trimIndent()
         )


### PR DESCRIPTION
Previously, the build script generated a `LibVersion.kt` containing the version string for every library with identical fully qualified names. So, in case you use multiple acp libraries (e.g. `acp` and `acp-model`), `com.agentclientprotocol.LIB_VERSION` could return a value of any of theses libraries. This fix adds the library name to the package name making it possible to distinguish between the individual `LIB_VERSION` constants.