### PR TITLE
Add Kotlin/JS support

### DIFF
--- a/acp-ktor-client/build.gradle.kts
+++ b/acp-ktor-client/build.gradle.kts
@@ -5,6 +5,11 @@ plugins {
 }
 
 kotlin {
+    js {
+        browser()
+        nodejs()
+    }
+
     sourceSets {
         commonMain {
             dependencies {

--- a/acp-ktor-test/build.gradle.kts
+++ b/acp-ktor-test/build.gradle.kts
@@ -3,6 +3,11 @@ plugins {
 }
 
 kotlin {
+    js {
+        browser()
+        nodejs()
+    }
+
     sourceSets {
         commonTest {
             dependencies {

--- a/acp-ktor/build.gradle.kts
+++ b/acp-ktor/build.gradle.kts
@@ -5,6 +5,11 @@ plugins {
 }
 
 kotlin {
+    js {
+        browser()
+        nodejs()
+    }
+
     sourceSets {
         commonMain {
             dependencies {

--- a/acp-model/build.gradle.kts
+++ b/acp-model/build.gradle.kts
@@ -5,6 +5,11 @@ plugins {
 }
 
 kotlin {
+    js {
+        browser()
+        nodejs()
+    }
+
     sourceSets {
         commonMain {
             dependencies {

--- a/acp/build.gradle.kts
+++ b/acp/build.gradle.kts
@@ -5,6 +5,11 @@ plugins {
 }
 
 kotlin {
+    js {
+        browser()
+        nodejs()
+    }
+
     sourceSets {
         commonMain {
             dependencies {

--- a/buildSrc/src/main/kotlin/acp.multiplatform.gradle.kts
+++ b/buildSrc/src/main/kotlin/acp.multiplatform.gradle.kts
@@ -1,3 +1,6 @@
+@file:OptIn(ExperimentalWasmDsl::class)
+
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
@@ -31,9 +34,9 @@ kotlin {
     jvm {
         compilerOptions.jvmTarget = JvmTarget.JVM_1_8
     }
+    js { nodejs() }
+    wasmJs { nodejs() }
     // Future multiplatform targets can be added here without changing the code
-//     js { nodejs() }
-     wasmJs { nodejs() }
 //     linuxX64(); macosX64(); mingwX64()
 
     explicitApi = ExplicitApiMode.Strict


### PR DESCRIPTION
- added kotlin/js target (nodejs) for all modules
- added kotlin/js target (browser) for all modules except `acp-ktor-server`

This simplifies acp integration into koog

### Testing
All multiplatform tests passed

### Breaking changes
None