### PR TITLE
fix: use single-arg limitedParallelism for coroutines 1.8 compat

### DIFF
--- a/acp/src/commonMain/kotlin/com/agentclientprotocol/protocol/Protocol.kt
+++ b/acp/src/commonMain/kotlin/com/agentclientprotocol/protocol/Protocol.kt
@@ -127,7 +127,7 @@ public class Protocol(
     private val scope = CoroutineScope(parentScope.coroutineContext + SupervisorJob(parentScope.coroutineContext[Job]) + CoroutineName(options.protocolDebugName))
     // a scope and dispatcher that executes requests to avoid blocking of message processing
     private val requestsScope = CoroutineScope(scope.coroutineContext + SupervisorJob(scope.coroutineContext[Job])
-            + Dispatchers.Default.limitedParallelism(parallelism = 1, name = "MessageProcessor") + CoroutineName(options.protocolDebugName))
+            + Dispatchers.Default.limitedParallelism(parallelism = 1) + CoroutineName(options.protocolDebugName))
     // now the incoming and outgoing requests can clash by ids, but it should not be a problem
     private val requestIdCounter: AtomicInt = atomic(0)
     private val pendingOutgoingRequests: AtomicRef<PersistentMap<OutgoingRequestId, CompletableDeferred<JsonElement>>> =


### PR DESCRIPTION
## Summary

- Replace `limitedParallelism(parallelism = 1, name = "MessageProcessor")` with `limitedParallelism(parallelism = 1)` in `Protocol.kt`
- The two-argument overload was added in kotlinx-coroutines 1.9.0, but IntelliJ Platform 2024.1–2025.1 bundles coroutines 1.7–1.8

## Problem

When ACP SDK is used as an IntelliJ plugin dependency, `Protocol` constructor crashes at runtime:

```
java.lang.NoSuchMethodError: 'kotlinx.coroutines.CoroutineDispatcher 
  kotlinx.coroutines.CoroutineDispatcher.limitedParallelism(int, java.lang.String)'
    at com.agentclientprotocol.protocol.Protocol.<init>(Protocol.kt:130)
```

IntelliJ plugins [must use the bundled coroutines library](https://plugins.jetbrains.com/docs/intellij/using-kotlin.html) — they cannot bundle their own version. The bundled versions by IDE release:

| IntelliJ Platform | Bundled coroutines | Has 2-arg `limitedParallelism`? |
|---|---|---|
| 2024.1 | 1.7.3 | No |
| 2024.2–2025.1 | 1.8.0-intellij-* | No |
| 2025.2+ | 1.10.1-intellij-* | Yes |

## Fix

The `name` parameter is optional and purely for debugging. The single-argument `limitedParallelism(Int)` is available since coroutines 1.6.0 and works on all IntelliJ Platform versions.