### PR TITLE
Increment sdk version to 0.20.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 private val buildNumber: String? = System.getenv("GITHUB_RUN_NUMBER")
 private val isReleasePublication = System.getenv("RELEASE_PUBLICATION")?.toBoolean() ?: false
 
-private val baseVersion = "0.20.0"
+private val baseVersion = "0.20.1"
 
 allprojects {
     group = "com.agentclientprotocol"


### PR DESCRIPTION
## Summary
- Bump `baseVersion` from `0.20.0` to `0.20.1` in `build.gradle.kts`

## Test plan
- [ ] Verify CI build passes with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)