### PR TITLE
forward compatible v2 enums

### DIFF
--- a/acp-model/api/acp-model.api
+++ b/acp-model/api/acp-model.api
@@ -7924,6 +7924,3541 @@ public final class com/agentclientprotocol/model/WriteTextFileResponse$Companion
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/agentclientprotocol/model/v2/AgentMessage {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/AgentMessage$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-Q0JOWoQ ()Ljava/lang/String;
+	public final fun component2 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun component3 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun copy-jGZKPAM (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;)Lcom/agentclientprotocol/model/v2/AgentMessage;
+	public static synthetic fun copy-jGZKPAM$default (Lcom/agentclientprotocol/model/v2/AgentMessage;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/AgentMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun getMessageId-Q0JOWoQ ()Ljava/lang/String;
+	public final fun get_meta ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/AgentMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/AgentThought {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/AgentThought$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-Q0JOWoQ ()Ljava/lang/String;
+	public final fun component2 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun component3 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun copy-jGZKPAM (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;)Lcom/agentclientprotocol/model/v2/AgentThought;
+	public static synthetic fun copy-jGZKPAM$default (Lcom/agentclientprotocol/model/v2/AgentThought;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/AgentThought;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun getMessageId-Q0JOWoQ ()Ljava/lang/String;
+	public final fun get_meta ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/AgentThought$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/Annotations : com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/Annotations$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/lang/Double;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/Double;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/Double;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/util/List;Ljava/lang/Double;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/Annotations;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/Annotations;Ljava/util/List;Ljava/lang/Double;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/Annotations;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAudience ()Ljava/util/List;
+	public final fun getLastModified ()Ljava/lang/String;
+	public final fun getPriority ()Ljava/lang/Double;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/Annotations$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/Annotations$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/Annotations;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/Annotations;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/Annotations$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/agentclientprotocol/model/v2/AuthMethod {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/AuthMethod$Companion;
+	public abstract fun getDescription ()Ljava/lang/String;
+	public abstract fun getMethodId-YMWAytM ()Ljava/lang/String;
+	public abstract fun getName ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/AuthMethod$Agent : com/agentclientprotocol/model/v2/AuthMethod, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/AuthMethod$Agent$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-YMWAytM ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy-6B2RdEM (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/AuthMethod$Agent;
+	public static synthetic fun copy-6B2RdEM$default (Lcom/agentclientprotocol/model/v2/AuthMethod$Agent;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/AuthMethod$Agent;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescription ()Ljava/lang/String;
+	public fun getMethodId-YMWAytM ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/AuthMethod$Agent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/AuthMethod$Agent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/AuthMethod$Agent;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/AuthMethod$Agent;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/AuthMethod$Agent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/AuthMethod$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/AuthMethod$EnvVar : com/agentclientprotocol/model/v2/AuthMethod, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/AuthMethod$EnvVar$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-YMWAytM ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy-m41MkYg (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/AuthMethod$EnvVar;
+	public static synthetic fun copy-m41MkYg$default (Lcom/agentclientprotocol/model/v2/AuthMethod$EnvVar;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/AuthMethod$EnvVar;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescription ()Ljava/lang/String;
+	public final fun getLink ()Ljava/lang/String;
+	public fun getMethodId-YMWAytM ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public final fun getVars ()Ljava/util/List;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/AuthMethod$EnvVar$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/AuthMethod$EnvVar$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/AuthMethod$EnvVar;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/AuthMethod$EnvVar;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/AuthMethod$EnvVar$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/AuthMethod$Terminal : com/agentclientprotocol/model/v2/AuthMethod, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/AuthMethod$Terminal$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-YMWAytM ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy-m41MkYg (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/AuthMethod$Terminal;
+	public static synthetic fun copy-m41MkYg$default (Lcom/agentclientprotocol/model/v2/AuthMethod$Terminal;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/AuthMethod$Terminal;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArgs ()Ljava/util/List;
+	public fun getDescription ()Ljava/lang/String;
+	public final fun getEnv ()Ljava/util/List;
+	public fun getMethodId-YMWAytM ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/AuthMethod$Terminal$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/AuthMethod$Terminal$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/AuthMethod$Terminal;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/AuthMethod$Terminal;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/AuthMethod$Terminal$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/AuthMethod$Unknown : com/agentclientprotocol/model/v2/AuthMethod {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2-YMWAytM ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-_LVAsAA (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lcom/agentclientprotocol/model/v2/AuthMethod$Unknown;
+	public static synthetic fun copy-_LVAsAA$default (Lcom/agentclientprotocol/model/v2/AuthMethod$Unknown;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/AuthMethod$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescription ()Ljava/lang/String;
+	public fun getMethodId-YMWAytM ()Ljava/lang/String;
+	public fun getName ()Ljava/lang/String;
+	public final fun getRawJson ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/AvailableCommand : com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/AvailableCommand$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/AvailableCommandInput;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/AvailableCommandInput;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/agentclientprotocol/model/v2/AvailableCommandInput;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/AvailableCommandInput;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/AvailableCommand;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/AvailableCommand;Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/AvailableCommandInput;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/AvailableCommand;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getInput ()Lcom/agentclientprotocol/model/v2/AvailableCommandInput;
+	public final fun getName ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/AvailableCommand$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/AvailableCommand$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/AvailableCommand;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/AvailableCommand;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/AvailableCommand$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/agentclientprotocol/model/v2/AvailableCommandInput {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/AvailableCommandInput$Companion;
+}
+
+public final class com/agentclientprotocol/model/v2/AvailableCommandInput$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/AvailableCommandInput$Text : com/agentclientprotocol/model/v2/AvailableCommandInput, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/AvailableCommandInput$Text$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/AvailableCommandInput$Text;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/AvailableCommandInput$Text;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/AvailableCommandInput$Text;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHint ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/AvailableCommandInput$Text$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/AvailableCommandInput$Text$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/AvailableCommandInput$Text;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/AvailableCommandInput$Text;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/AvailableCommandInput$Text$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/AvailableCommandInput$Unknown : com/agentclientprotocol/model/v2/AvailableCommandInput {
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lcom/agentclientprotocol/model/v2/AvailableCommandInput$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/AvailableCommandInput$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/AvailableCommandInput$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRawJson ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/AvailableCommandsUpdate : com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/AvailableCommandsUpdate$Companion;
+	public fun <init> (Ljava/util/List;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/util/List;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/util/List;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/AvailableCommandsUpdate;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/AvailableCommandsUpdate;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/AvailableCommandsUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvailableCommands ()Ljava/util/List;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/AvailableCommandsUpdate$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/AvailableCommandsUpdate$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/AvailableCommandsUpdate;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/AvailableCommandsUpdate;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/AvailableCommandsUpdate$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ConfigOptionUpdate : com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ConfigOptionUpdate$Companion;
+	public fun <init> (Ljava/util/List;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/util/List;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/util/List;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/ConfigOptionUpdate;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ConfigOptionUpdate;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ConfigOptionUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConfigOptions ()Ljava/util/List;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/ConfigOptionUpdate$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ConfigOptionUpdate$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/ConfigOptionUpdate;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/ConfigOptionUpdate;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ConfigOptionUpdate$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/agentclientprotocol/model/v2/ContentBlock {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ContentBlock$Companion;
+}
+
+public final class com/agentclientprotocol/model/v2/ContentBlock$Audio : com/agentclientprotocol/model/v2/ContentBlock, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ContentBlock$Audio$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/agentclientprotocol/model/v2/Annotations;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/ContentBlock$Audio;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ContentBlock$Audio;Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ContentBlock$Audio;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnnotations ()Lcom/agentclientprotocol/model/v2/Annotations;
+	public final fun getData ()Ljava/lang/String;
+	public final fun getMimeType ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/ContentBlock$Audio$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ContentBlock$Audio$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/ContentBlock$Audio;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/ContentBlock$Audio;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ContentBlock$Audio$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ContentBlock$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ContentBlock$Image : com/agentclientprotocol/model/v2/ContentBlock, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ContentBlock$Image$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/agentclientprotocol/model/v2/Annotations;
+	public final fun component5 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/ContentBlock$Image;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ContentBlock$Image;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ContentBlock$Image;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnnotations ()Lcom/agentclientprotocol/model/v2/Annotations;
+	public final fun getData ()Ljava/lang/String;
+	public final fun getMimeType ()Ljava/lang/String;
+	public final fun getUri ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/ContentBlock$Image$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ContentBlock$Image$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/ContentBlock$Image;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/ContentBlock$Image;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ContentBlock$Image$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ContentBlock$Resource : com/agentclientprotocol/model/v2/ContentBlock, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ContentBlock$Resource$Companion;
+	public fun <init> (Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource;
+	public final fun component2 ()Lcom/agentclientprotocol/model/v2/Annotations;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/ContentBlock$Resource;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ContentBlock$Resource;Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ContentBlock$Resource;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnnotations ()Lcom/agentclientprotocol/model/v2/Annotations;
+	public final fun getResource ()Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/ContentBlock$Resource$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ContentBlock$Resource$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/ContentBlock$Resource;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/ContentBlock$Resource;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ContentBlock$Resource$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ContentBlock$ResourceLink : com/agentclientprotocol/model/v2/ContentBlock, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ContentBlock$ResourceLink$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/util/List;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/util/List;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Lcom/agentclientprotocol/model/v2/Annotations;
+	public final fun component9 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/util/List;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/ContentBlock$ResourceLink;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ContentBlock$ResourceLink;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/util/List;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ContentBlock$ResourceLink;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnnotations ()Lcom/agentclientprotocol/model/v2/Annotations;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getIcons ()Ljava/util/List;
+	public final fun getMimeType ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSize ()Ljava/lang/Long;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getUri ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/ContentBlock$ResourceLink$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ContentBlock$ResourceLink$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/ContentBlock$ResourceLink;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/ContentBlock$ResourceLink;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ContentBlock$ResourceLink$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ContentBlock$Text : com/agentclientprotocol/model/v2/ContentBlock, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ContentBlock$Text$Companion;
+	public fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/agentclientprotocol/model/v2/Annotations;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/ContentBlock$Text;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ContentBlock$Text;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/Annotations;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ContentBlock$Text;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnnotations ()Lcom/agentclientprotocol/model/v2/Annotations;
+	public final fun getText ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/ContentBlock$Text$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ContentBlock$Text$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/ContentBlock$Text;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/ContentBlock$Text;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ContentBlock$Text$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ContentBlock$Unknown : com/agentclientprotocol/model/v2/ContentBlock {
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lcom/agentclientprotocol/model/v2/ContentBlock$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ContentBlock$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ContentBlock$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRawJson ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ContentChunk : com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ContentChunk$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/ContentBlock;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/ContentBlock;Lkotlinx/serialization/json/JsonElement;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-Q0JOWoQ ()Ljava/lang/String;
+	public final fun component2 ()Lcom/agentclientprotocol/model/v2/ContentBlock;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy-jGZKPAM (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/ContentBlock;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/ContentChunk;
+	public static synthetic fun copy-jGZKPAM$default (Lcom/agentclientprotocol/model/v2/ContentChunk;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/ContentBlock;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ContentChunk;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Lcom/agentclientprotocol/model/v2/ContentBlock;
+	public final fun getMessageId-Q0JOWoQ ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/ContentChunk$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ContentChunk$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/ContentChunk;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/ContentChunk;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ContentChunk$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/DiffChange : com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/DiffChange$Companion;
+	public fun <init> (Lcom/agentclientprotocol/model/v2/DiffChangeOperation;Lcom/agentclientprotocol/model/v2/DiffFileType;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Lcom/agentclientprotocol/model/v2/DiffChangeOperation;Lcom/agentclientprotocol/model/v2/DiffFileType;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/DiffChangeOperation;
+	public final fun component2 ()Lcom/agentclientprotocol/model/v2/DiffFileType;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/DiffChangeOperation;Lcom/agentclientprotocol/model/v2/DiffFileType;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/DiffChange;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/DiffChange;Lcom/agentclientprotocol/model/v2/DiffChangeOperation;Lcom/agentclientprotocol/model/v2/DiffFileType;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/DiffChange;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFileType ()Lcom/agentclientprotocol/model/v2/DiffFileType;
+	public final fun getMimeType ()Ljava/lang/String;
+	public final fun getOperation ()Lcom/agentclientprotocol/model/v2/DiffChangeOperation;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/DiffChange$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/agentclientprotocol/model/v2/DiffChangeOperation {
+}
+
+public final class com/agentclientprotocol/model/v2/DiffChangeOperation$Add : com/agentclientprotocol/model/v2/DiffChangeOperation {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/DiffChangeOperation$Add;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/DiffChangeOperation$Add;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/DiffChangeOperation$Add;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/DiffChangeOperation$Copy : com/agentclientprotocol/model/v2/DiffChangeOperation {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/DiffChangeOperation$Copy;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/DiffChangeOperation$Copy;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/DiffChangeOperation$Copy;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOldPath ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/DiffChangeOperation$Delete : com/agentclientprotocol/model/v2/DiffChangeOperation {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/DiffChangeOperation$Delete;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/DiffChangeOperation$Delete;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/DiffChangeOperation$Delete;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/DiffChangeOperation$Modify : com/agentclientprotocol/model/v2/DiffChangeOperation {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/DiffChangeOperation$Modify;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/DiffChangeOperation$Modify;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/DiffChangeOperation$Modify;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/DiffChangeOperation$Move : com/agentclientprotocol/model/v2/DiffChangeOperation {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/DiffChangeOperation$Move;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/DiffChangeOperation$Move;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/DiffChangeOperation$Move;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOldPath ()Ljava/lang/String;
+	public final fun getPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/DiffChangeOperation$Unknown : com/agentclientprotocol/model/v2/DiffChangeOperation {
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lcom/agentclientprotocol/model/v2/DiffChangeOperation$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/DiffChangeOperation$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/DiffChangeOperation$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFields ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getOperation ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/DiffFileType {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/DiffFileType$Companion;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/DiffFileType$Binary : com/agentclientprotocol/model/v2/DiffFileType {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/DiffFileType$Binary;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/DiffFileType$Companion {
+	public final fun extension (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/DiffFileType$Unknown;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/DiffFileType$Directory : com/agentclientprotocol/model/v2/DiffFileType {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/DiffFileType$Directory;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/DiffFileType$Symlink : com/agentclientprotocol/model/v2/DiffFileType {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/DiffFileType$Symlink;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/DiffFileType$Text : com/agentclientprotocol/model/v2/DiffFileType {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/DiffFileType$Text;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/DiffFileType$Unknown : com/agentclientprotocol/model/v2/DiffFileType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/DiffFileType$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/DiffFileType$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/DiffFileType$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/DiffPatch {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/DiffPatch$Companion;
+	public fun <init> (Lcom/agentclientprotocol/model/v2/DiffPatchFormat;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/agentclientprotocol/model/v2/DiffPatchFormat;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/DiffPatchFormat;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/DiffPatchFormat;Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/DiffPatch;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/DiffPatch;Lcom/agentclientprotocol/model/v2/DiffPatchFormat;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/DiffPatch;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDiff ()Ljava/lang/String;
+	public final fun getFormat ()Lcom/agentclientprotocol/model/v2/DiffPatchFormat;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/DiffPatch$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/DiffPatch$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/DiffPatch;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/DiffPatch;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/DiffPatch$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/agentclientprotocol/model/v2/DiffPatchFormat {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/DiffPatchFormat$Companion;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/DiffPatchFormat$Companion {
+	public final fun extension (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/DiffPatchFormat$Unknown;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/DiffPatchFormat$GitPatch : com/agentclientprotocol/model/v2/DiffPatchFormat {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/DiffPatchFormat$GitPatch;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/DiffPatchFormat$Unknown : com/agentclientprotocol/model/v2/DiffPatchFormat {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/DiffPatchFormat$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/DiffPatchFormat$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/DiffPatchFormat$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/ElicitationAction {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ElicitationAction$Companion;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationAction$Accept : com/agentclientprotocol/model/v2/ElicitationAction {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ElicitationAction$Accept$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;)Lcom/agentclientprotocol/model/v2/ElicitationAction$Accept;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ElicitationAction$Accept;Ljava/util/Map;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ElicitationAction$Accept;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/ElicitationAction$Accept$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ElicitationAction$Accept$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/ElicitationAction$Accept;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/ElicitationAction$Accept;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationAction$Accept$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationAction$Cancel : com/agentclientprotocol/model/v2/ElicitationAction {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ElicitationAction$Cancel;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationAction$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationAction$Decline : com/agentclientprotocol/model/v2/ElicitationAction {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ElicitationAction$Decline;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationAction$Unknown : com/agentclientprotocol/model/v2/ElicitationAction {
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lcom/agentclientprotocol/model/v2/ElicitationAction$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ElicitationAction$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ElicitationAction$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Ljava/lang/String;
+	public final fun getRawJson ()Lkotlinx/serialization/json/JsonObject;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/ElicitationMode {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ElicitationMode$Companion;
+	public abstract fun getScope ()Lcom/agentclientprotocol/model/ElicitationScope;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationMode$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationMode$Form : com/agentclientprotocol/model/v2/ElicitationMode {
+	public fun <init> (Lcom/agentclientprotocol/model/ElicitationScope;Lcom/agentclientprotocol/model/v2/ElicitationSchema;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/ElicitationScope;
+	public final fun component2 ()Lcom/agentclientprotocol/model/v2/ElicitationSchema;
+	public final fun copy (Lcom/agentclientprotocol/model/ElicitationScope;Lcom/agentclientprotocol/model/v2/ElicitationSchema;)Lcom/agentclientprotocol/model/v2/ElicitationMode$Form;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ElicitationMode$Form;Lcom/agentclientprotocol/model/ElicitationScope;Lcom/agentclientprotocol/model/v2/ElicitationSchema;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ElicitationMode$Form;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRequestedSchema ()Lcom/agentclientprotocol/model/v2/ElicitationSchema;
+	public fun getScope ()Lcom/agentclientprotocol/model/ElicitationScope;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationMode$Unknown : com/agentclientprotocol/model/v2/ElicitationMode {
+	public fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/ElicitationScope;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/agentclientprotocol/model/ElicitationScope;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lcom/agentclientprotocol/model/ElicitationScope;Lkotlinx/serialization/json/JsonObject;)Lcom/agentclientprotocol/model/v2/ElicitationMode$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ElicitationMode$Unknown;Ljava/lang/String;Lcom/agentclientprotocol/model/ElicitationScope;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ElicitationMode$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMode ()Ljava/lang/String;
+	public final fun getRawJson ()Lkotlinx/serialization/json/JsonObject;
+	public fun getScope ()Lcom/agentclientprotocol/model/ElicitationScope;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationMode$Url : com/agentclientprotocol/model/v2/ElicitationMode {
+	public synthetic fun <init> (Lcom/agentclientprotocol/model/ElicitationScope;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/ElicitationScope;
+	public final fun component2-WWIfWFI ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy-1FbYFr8 (Lcom/agentclientprotocol/model/ElicitationScope;Ljava/lang/String;Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/ElicitationMode$Url;
+	public static synthetic fun copy-1FbYFr8$default (Lcom/agentclientprotocol/model/v2/ElicitationMode$Url;Lcom/agentclientprotocol/model/ElicitationScope;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ElicitationMode$Url;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getElicitationId-WWIfWFI ()Ljava/lang/String;
+	public fun getScope ()Lcom/agentclientprotocol/model/ElicitationScope;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/ElicitationPropertySchema {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$Companion;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationPropertySchema$ArrayProperty : com/agentclientprotocol/model/v2/ElicitationPropertySchema {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$ArrayProperty$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lcom/agentclientprotocol/model/v2/MultiSelectItems;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lcom/agentclientprotocol/model/v2/MultiSelectItems;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun component5 ()Lcom/agentclientprotocol/model/v2/MultiSelectItems;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lcom/agentclientprotocol/model/v2/MultiSelectItems;Ljava/util/List;)Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$ArrayProperty;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$ArrayProperty;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lcom/agentclientprotocol/model/v2/MultiSelectItems;Ljava/util/List;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$ArrayProperty;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefault ()Ljava/util/List;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getItems ()Lcom/agentclientprotocol/model/v2/MultiSelectItems;
+	public final fun getMaxItems ()Ljava/lang/Long;
+	public final fun getMinItems ()Ljava/lang/Long;
+	public final fun getTitle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/ElicitationPropertySchema$ArrayProperty$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$ArrayProperty$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$ArrayProperty;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$ArrayProperty;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationPropertySchema$ArrayProperty$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationPropertySchema$BooleanProperty : com/agentclientprotocol/model/v2/ElicitationPropertySchema {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$BooleanProperty$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$BooleanProperty;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$BooleanProperty;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$BooleanProperty;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefault ()Ljava/lang/Boolean;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/ElicitationPropertySchema$BooleanProperty$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$BooleanProperty$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$BooleanProperty;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$BooleanProperty;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationPropertySchema$BooleanProperty$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationPropertySchema$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationPropertySchema$IntegerProperty : com/agentclientprotocol/model/v2/ElicitationPropertySchema {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$IntegerProperty$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$IntegerProperty;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$IntegerProperty;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$IntegerProperty;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefault ()Ljava/lang/Long;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getMaximum ()Ljava/lang/Long;
+	public final fun getMinimum ()Ljava/lang/Long;
+	public final fun getTitle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/ElicitationPropertySchema$IntegerProperty$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$IntegerProperty$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$IntegerProperty;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$IntegerProperty;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationPropertySchema$IntegerProperty$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationPropertySchema$NumberProperty : com/agentclientprotocol/model/v2/ElicitationPropertySchema {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$NumberProperty$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Double;
+	public final fun component4 ()Ljava/lang/Double;
+	public final fun component5 ()Ljava/lang/Double;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;)Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$NumberProperty;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$NumberProperty;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$NumberProperty;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefault ()Ljava/lang/Double;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getMaximum ()Ljava/lang/Double;
+	public final fun getMinimum ()Ljava/lang/Double;
+	public final fun getTitle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/ElicitationPropertySchema$NumberProperty$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$NumberProperty$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$NumberProperty;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$NumberProperty;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationPropertySchema$NumberProperty$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationPropertySchema$StringProperty : com/agentclientprotocol/model/v2/ElicitationPropertySchema {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$StringProperty$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/StringFormat;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/StringFormat;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lcom/agentclientprotocol/model/v2/StringFormat;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/StringFormat;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$StringProperty;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$StringProperty;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/StringFormat;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$StringProperty;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefault ()Ljava/lang/String;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getEnumValues ()Ljava/util/List;
+	public final fun getFormat ()Lcom/agentclientprotocol/model/v2/StringFormat;
+	public final fun getMaxLength ()Ljava/lang/Integer;
+	public final fun getMinLength ()Ljava/lang/Integer;
+	public final fun getOneOf ()Ljava/util/List;
+	public final fun getPattern ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/ElicitationPropertySchema$StringProperty$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$StringProperty$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$StringProperty;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$StringProperty;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationPropertySchema$StringProperty$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationPropertySchema$Unknown : com/agentclientprotocol/model/v2/ElicitationPropertySchema {
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRawJson ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationSchema {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ElicitationSchema$Companion;
+	public fun <init> ()V
+	public fun <init> (Lcom/agentclientprotocol/model/ElicitationSchemaType;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/agentclientprotocol/model/ElicitationSchemaType;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/ElicitationSchemaType;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Lcom/agentclientprotocol/model/ElicitationSchemaType;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/ElicitationSchema;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ElicitationSchema;Lcom/agentclientprotocol/model/ElicitationSchemaType;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ElicitationSchema;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getProperties ()Ljava/util/Map;
+	public final fun getRequired ()Ljava/util/List;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getType ()Lcom/agentclientprotocol/model/ElicitationSchemaType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/ElicitationSchema$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ElicitationSchema$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/ElicitationSchema;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/ElicitationSchema;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ElicitationSchema$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/agentclientprotocol/model/v2/EmbeddedResourceResource : com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource$Companion;
+}
+
+public final class com/agentclientprotocol/model/v2/EmbeddedResourceResource$BlobResourceContents : com/agentclientprotocol/model/v2/EmbeddedResourceResource {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource$BlobResourceContents$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource$BlobResourceContents;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource$BlobResourceContents;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource$BlobResourceContents;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlob ()Ljava/lang/String;
+	public final fun getMimeType ()Ljava/lang/String;
+	public final fun getUri ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/EmbeddedResourceResource$BlobResourceContents$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource$BlobResourceContents$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource$BlobResourceContents;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource$BlobResourceContents;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/EmbeddedResourceResource$BlobResourceContents$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/EmbeddedResourceResource$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/EmbeddedResourceResource$TextResourceContents : com/agentclientprotocol/model/v2/EmbeddedResourceResource {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource$TextResourceContents$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource$TextResourceContents;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource$TextResourceContents;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource$TextResourceContents;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMimeType ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getUri ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/EmbeddedResourceResource$TextResourceContents$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource$TextResourceContents$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource$TextResourceContents;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource$TextResourceContents;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/EmbeddedResourceResource$TextResourceContents$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/Icon {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/Icon$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/agentclientprotocol/model/v2/IconTheme;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/agentclientprotocol/model/v2/IconTheme;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Lcom/agentclientprotocol/model/v2/IconTheme;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/agentclientprotocol/model/v2/IconTheme;)Lcom/agentclientprotocol/model/v2/Icon;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/Icon;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/agentclientprotocol/model/v2/IconTheme;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/Icon;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMimeType ()Ljava/lang/String;
+	public final fun getSizes ()Ljava/util/List;
+	public final fun getSrc ()Ljava/lang/String;
+	public final fun getTheme ()Lcom/agentclientprotocol/model/v2/IconTheme;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/Icon$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/Icon$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/Icon;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/Icon;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/Icon$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/agentclientprotocol/model/v2/IconTheme {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/IconTheme$Companion;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/IconTheme$Companion {
+	public final fun extension (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/IconTheme$Unknown;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/IconTheme$Dark : com/agentclientprotocol/model/v2/IconTheme {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/IconTheme$Dark;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/IconTheme$Light : com/agentclientprotocol/model/v2/IconTheme {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/IconTheme$Light;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/IconTheme$Unknown : com/agentclientprotocol/model/v2/IconTheme {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/IconTheme$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/IconTheme$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/IconTheme$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/LlmProtocol {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/LlmProtocol$Companion;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/LlmProtocol$Anthropic : com/agentclientprotocol/model/v2/LlmProtocol {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/LlmProtocol$Anthropic;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/LlmProtocol$Azure : com/agentclientprotocol/model/v2/LlmProtocol {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/LlmProtocol$Azure;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/LlmProtocol$Bedrock : com/agentclientprotocol/model/v2/LlmProtocol {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/LlmProtocol$Bedrock;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/LlmProtocol$Companion {
+	public final fun extension (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/LlmProtocol$Unknown;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/LlmProtocol$OpenAi : com/agentclientprotocol/model/v2/LlmProtocol {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/LlmProtocol$OpenAi;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/LlmProtocol$Unknown : com/agentclientprotocol/model/v2/LlmProtocol {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/LlmProtocol$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/LlmProtocol$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/LlmProtocol$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/LlmProtocol$Vertex : com/agentclientprotocol/model/v2/LlmProtocol {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/LlmProtocol$Vertex;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/MaybeUndefined {
+	public final fun map (Lkotlin/jvm/functions/Function1;)Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun valueOrNull ()Ljava/lang/Object;
+}
+
+public final class com/agentclientprotocol/model/v2/MaybeUndefined$Null : com/agentclientprotocol/model/v2/MaybeUndefined {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/MaybeUndefined$Null;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/MaybeUndefined$Undefined : com/agentclientprotocol/model/v2/MaybeUndefined {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/MaybeUndefined$Undefined;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/MaybeUndefined$Value : com/agentclientprotocol/model/v2/MaybeUndefined {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;)Lcom/agentclientprotocol/model/v2/MaybeUndefined$Value;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/MaybeUndefined$Value;Ljava/lang/Object;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/MaybeUndefined$Value;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/MaybeUndefinedKt {
+	public static final fun update (Lcom/agentclientprotocol/model/v2/MaybeUndefined;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract class com/agentclientprotocol/model/v2/McpServer {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/McpServer$Companion;
+}
+
+public final class com/agentclientprotocol/model/v2/McpServer$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/McpServer$Http : com/agentclientprotocol/model/v2/McpServer, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/McpServer$Http$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/McpServer$Http;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/McpServer$Http;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/McpServer$Http;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeaders ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/McpServer$Http$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/McpServer$Http$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/McpServer$Http;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/McpServer$Http;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/McpServer$Http$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/McpServer$Stdio : com/agentclientprotocol/model/v2/McpServer, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/McpServer$Stdio$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/McpServer$Stdio;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/McpServer$Stdio;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/McpServer$Stdio;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArgs ()Ljava/util/List;
+	public final fun getCommand ()Ljava/lang/String;
+	public final fun getEnv ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/McpServer$Stdio$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/McpServer$Stdio$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/McpServer$Stdio;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/McpServer$Stdio;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/McpServer$Stdio$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/McpServer$Unknown : com/agentclientprotocol/model/v2/McpServer {
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lcom/agentclientprotocol/model/v2/McpServer$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/McpServer$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/McpServer$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRawJson ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/MultiSelectItems {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/MultiSelectItems$Companion;
+}
+
+public final class com/agentclientprotocol/model/v2/MultiSelectItems$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/MultiSelectItems$StringItems : com/agentclientprotocol/model/v2/MultiSelectItems {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/MultiSelectItems$StringItems$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/agentclientprotocol/model/v2/MultiSelectItems$StringItems;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/MultiSelectItems$StringItems;Ljava/util/List;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/MultiSelectItems$StringItems;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValues ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/MultiSelectItems$StringItems$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/MultiSelectItems$StringItems$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/MultiSelectItems$StringItems;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/MultiSelectItems$StringItems;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/MultiSelectItems$StringItems$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/MultiSelectItems$Titled : com/agentclientprotocol/model/v2/MultiSelectItems {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/MultiSelectItems$Titled$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/agentclientprotocol/model/v2/MultiSelectItems$Titled;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/MultiSelectItems$Titled;Ljava/util/List;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/MultiSelectItems$Titled;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOptions ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/MultiSelectItems$Titled$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/MultiSelectItems$Titled$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/MultiSelectItems$Titled;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/MultiSelectItems$Titled;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/MultiSelectItems$Titled$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/MultiSelectItems$Unknown : com/agentclientprotocol/model/v2/MultiSelectItems {
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lcom/agentclientprotocol/model/v2/MultiSelectItems$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/MultiSelectItems$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/MultiSelectItems$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRawJson ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/NesDiagnosticSeverity {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/NesDiagnosticSeverity$Companion;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/NesDiagnosticSeverity$Companion {
+	public final fun extension (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/NesDiagnosticSeverity$Unknown;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/NesDiagnosticSeverity$Error : com/agentclientprotocol/model/v2/NesDiagnosticSeverity {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/NesDiagnosticSeverity$Error;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/NesDiagnosticSeverity$Hint : com/agentclientprotocol/model/v2/NesDiagnosticSeverity {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/NesDiagnosticSeverity$Hint;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/NesDiagnosticSeverity$Information : com/agentclientprotocol/model/v2/NesDiagnosticSeverity {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/NesDiagnosticSeverity$Information;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/NesDiagnosticSeverity$Unknown : com/agentclientprotocol/model/v2/NesDiagnosticSeverity {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/NesDiagnosticSeverity$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/NesDiagnosticSeverity$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/NesDiagnosticSeverity$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/NesDiagnosticSeverity$Warning : com/agentclientprotocol/model/v2/NesDiagnosticSeverity {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/NesDiagnosticSeverity$Warning;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/NesRejectReason {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/NesRejectReason$Companion;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/NesRejectReason$Cancelled : com/agentclientprotocol/model/v2/NesRejectReason {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/NesRejectReason$Cancelled;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/NesRejectReason$Companion {
+	public final fun extension (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/NesRejectReason$Unknown;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/NesRejectReason$Ignored : com/agentclientprotocol/model/v2/NesRejectReason {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/NesRejectReason$Ignored;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/NesRejectReason$Rejected : com/agentclientprotocol/model/v2/NesRejectReason {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/NesRejectReason$Rejected;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/NesRejectReason$Replaced : com/agentclientprotocol/model/v2/NesRejectReason {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/NesRejectReason$Replaced;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/NesRejectReason$Unknown : com/agentclientprotocol/model/v2/NesRejectReason {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/NesRejectReason$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/NesRejectReason$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/NesRejectReason$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/NesSuggestion {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/NesSuggestion$Companion;
+	public abstract fun getSuggestionId ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/NesSuggestion$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/NesSuggestion$Edit : com/agentclientprotocol/model/v2/NesSuggestion {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/NesSuggestion$Edit$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/agentclientprotocol/model/NesPosition;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/agentclientprotocol/model/NesPosition;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Lcom/agentclientprotocol/model/NesPosition;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/agentclientprotocol/model/NesPosition;)Lcom/agentclientprotocol/model/v2/NesSuggestion$Edit;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/NesSuggestion$Edit;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/agentclientprotocol/model/NesPosition;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/NesSuggestion$Edit;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCursorPosition ()Lcom/agentclientprotocol/model/NesPosition;
+	public final fun getEdits ()Ljava/util/List;
+	public fun getSuggestionId ()Ljava/lang/String;
+	public final fun getUri ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/NesSuggestion$Edit$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/NesSuggestion$Edit$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/NesSuggestion$Edit;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/NesSuggestion$Edit;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/NesSuggestion$Edit$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/NesSuggestion$Jump : com/agentclientprotocol/model/v2/NesSuggestion {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/NesSuggestion$Jump$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/NesPosition;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/agentclientprotocol/model/NesPosition;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/NesPosition;)Lcom/agentclientprotocol/model/v2/NesSuggestion$Jump;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/NesSuggestion$Jump;Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/NesPosition;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/NesSuggestion$Jump;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPosition ()Lcom/agentclientprotocol/model/NesPosition;
+	public fun getSuggestionId ()Ljava/lang/String;
+	public final fun getUri ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/NesSuggestion$Jump$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/NesSuggestion$Jump$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/NesSuggestion$Jump;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/NesSuggestion$Jump;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/NesSuggestion$Jump$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/NesSuggestion$Rename : com/agentclientprotocol/model/v2/NesSuggestion {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/NesSuggestion$Rename$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/NesPosition;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/agentclientprotocol/model/NesPosition;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/NesPosition;Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/NesSuggestion$Rename;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/NesSuggestion$Rename;Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/NesPosition;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/NesSuggestion$Rename;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNewName ()Ljava/lang/String;
+	public final fun getPosition ()Lcom/agentclientprotocol/model/NesPosition;
+	public fun getSuggestionId ()Ljava/lang/String;
+	public final fun getUri ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/NesSuggestion$Rename$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/NesSuggestion$Rename$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/NesSuggestion$Rename;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/NesSuggestion$Rename;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/NesSuggestion$Rename$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/NesSuggestion$SearchAndReplace : com/agentclientprotocol/model/v2/NesSuggestion {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/NesSuggestion$SearchAndReplace$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/agentclientprotocol/model/v2/NesSuggestion$SearchAndReplace;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/NesSuggestion$SearchAndReplace;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/NesSuggestion$SearchAndReplace;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReplace ()Ljava/lang/String;
+	public final fun getSearch ()Ljava/lang/String;
+	public fun getSuggestionId ()Ljava/lang/String;
+	public final fun getUri ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isRegex ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/NesSuggestion$SearchAndReplace$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/NesSuggestion$SearchAndReplace$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/NesSuggestion$SearchAndReplace;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/NesSuggestion$SearchAndReplace;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/NesSuggestion$SearchAndReplace$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/NesSuggestion$Unknown : com/agentclientprotocol/model/v2/NesSuggestion {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lcom/agentclientprotocol/model/v2/NesSuggestion$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/NesSuggestion$Unknown;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/NesSuggestion$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getRawJson ()Lkotlinx/serialization/json/JsonObject;
+	public fun getSuggestionId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/NesTriggerKind {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/NesTriggerKind$Companion;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/NesTriggerKind$Automatic : com/agentclientprotocol/model/v2/NesTriggerKind {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/NesTriggerKind$Automatic;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/NesTriggerKind$Companion {
+	public final fun extension (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/NesTriggerKind$Unknown;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/NesTriggerKind$Diagnostic : com/agentclientprotocol/model/v2/NesTriggerKind {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/NesTriggerKind$Diagnostic;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/NesTriggerKind$Manual : com/agentclientprotocol/model/v2/NesTriggerKind {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/NesTriggerKind$Manual;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/NesTriggerKind$Unknown : com/agentclientprotocol/model/v2/NesTriggerKind {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/NesTriggerKind$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/NesTriggerKind$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/NesTriggerKind$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/PermissionOptionKind {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/PermissionOptionKind$Companion;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/PermissionOptionKind$AllowAlways : com/agentclientprotocol/model/v2/PermissionOptionKind {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/PermissionOptionKind$AllowAlways;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/PermissionOptionKind$AllowOnce : com/agentclientprotocol/model/v2/PermissionOptionKind {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/PermissionOptionKind$AllowOnce;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/PermissionOptionKind$Companion {
+	public final fun extension (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/PermissionOptionKind$Unknown;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/PermissionOptionKind$RejectAlways : com/agentclientprotocol/model/v2/PermissionOptionKind {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/PermissionOptionKind$RejectAlways;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/PermissionOptionKind$RejectOnce : com/agentclientprotocol/model/v2/PermissionOptionKind {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/PermissionOptionKind$RejectOnce;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/PermissionOptionKind$Unknown : com/agentclientprotocol/model/v2/PermissionOptionKind {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/PermissionOptionKind$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/PermissionOptionKind$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/PermissionOptionKind$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanEntry : com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/PlanEntry$Companion;
+	public fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/PlanEntryPriority;Lcom/agentclientprotocol/model/v2/PlanEntryStatus;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/PlanEntryPriority;Lcom/agentclientprotocol/model/v2/PlanEntryStatus;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/agentclientprotocol/model/v2/PlanEntryPriority;
+	public final fun component3 ()Lcom/agentclientprotocol/model/v2/PlanEntryStatus;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/PlanEntryPriority;Lcom/agentclientprotocol/model/v2/PlanEntryStatus;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/PlanEntry;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/PlanEntry;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/PlanEntryPriority;Lcom/agentclientprotocol/model/v2/PlanEntryStatus;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/PlanEntry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Ljava/lang/String;
+	public final fun getPriority ()Lcom/agentclientprotocol/model/v2/PlanEntryPriority;
+	public final fun getStatus ()Lcom/agentclientprotocol/model/v2/PlanEntryStatus;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/PlanEntry$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/PlanEntry$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/PlanEntry;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/PlanEntry;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanEntry$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/agentclientprotocol/model/v2/PlanEntryPriority {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/PlanEntryPriority$Companion;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanEntryPriority$Companion {
+	public final fun extension (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/PlanEntryPriority$Unknown;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanEntryPriority$High : com/agentclientprotocol/model/v2/PlanEntryPriority {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/PlanEntryPriority$High;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanEntryPriority$Low : com/agentclientprotocol/model/v2/PlanEntryPriority {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/PlanEntryPriority$Low;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanEntryPriority$Medium : com/agentclientprotocol/model/v2/PlanEntryPriority {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/PlanEntryPriority$Medium;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanEntryPriority$Unknown : com/agentclientprotocol/model/v2/PlanEntryPriority {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/PlanEntryPriority$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/PlanEntryPriority$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/PlanEntryPriority$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/PlanEntryStatus {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/PlanEntryStatus$Companion;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanEntryStatus$Companion {
+	public final fun extension (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/PlanEntryStatus$Unknown;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanEntryStatus$Completed : com/agentclientprotocol/model/v2/PlanEntryStatus {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/PlanEntryStatus$Completed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanEntryStatus$InProgress : com/agentclientprotocol/model/v2/PlanEntryStatus {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/PlanEntryStatus$InProgress;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanEntryStatus$Pending : com/agentclientprotocol/model/v2/PlanEntryStatus {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/PlanEntryStatus$Pending;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanEntryStatus$Unknown : com/agentclientprotocol/model/v2/PlanEntryStatus {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/PlanEntryStatus$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/PlanEntryStatus$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/PlanEntryStatus$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanId {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/PlanId$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/PlanId;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/PlanId$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/PlanId$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize-AeK1G_4 (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/String;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize-FLLiJxM (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanId$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanRemoved : com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/PlanRemoved$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-RbgNvSo ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy-j4oLsNw (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/PlanRemoved;
+	public static synthetic fun copy-j4oLsNw$default (Lcom/agentclientprotocol/model/v2/PlanRemoved;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/PlanRemoved;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPlanId-RbgNvSo ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/PlanRemoved$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/PlanRemoved$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/PlanRemoved;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/PlanRemoved;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanRemoved$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanUpdate : com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/PlanUpdate$Companion;
+	public fun <init> (Lcom/agentclientprotocol/model/v2/PlanUpdateContent;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Lcom/agentclientprotocol/model/v2/PlanUpdateContent;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/PlanUpdateContent;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/PlanUpdateContent;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/PlanUpdate;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/PlanUpdate;Lcom/agentclientprotocol/model/v2/PlanUpdateContent;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/PlanUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPlan ()Lcom/agentclientprotocol/model/v2/PlanUpdateContent;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/PlanUpdate$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/PlanUpdate$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/PlanUpdate;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/PlanUpdate;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanUpdate$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/agentclientprotocol/model/v2/PlanUpdateContent {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/PlanUpdateContent$Companion;
+	public abstract fun getPlanId-RbgNvSo ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanUpdateContent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanUpdateContent$File : com/agentclientprotocol/model/v2/PlanUpdateContent, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/PlanUpdateContent$File$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-RbgNvSo ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy-THESmG4 (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/PlanUpdateContent$File;
+	public static synthetic fun copy-THESmG4$default (Lcom/agentclientprotocol/model/v2/PlanUpdateContent$File;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/PlanUpdateContent$File;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getPlanId-RbgNvSo ()Ljava/lang/String;
+	public final fun getUri ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/PlanUpdateContent$File$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/PlanUpdateContent$File$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/PlanUpdateContent$File;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/PlanUpdateContent$File;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanUpdateContent$File$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanUpdateContent$Items : com/agentclientprotocol/model/v2/PlanUpdateContent, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/PlanUpdateContent$Items$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-RbgNvSo ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy-THESmG4 (Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/PlanUpdateContent$Items;
+	public static synthetic fun copy-THESmG4$default (Lcom/agentclientprotocol/model/v2/PlanUpdateContent$Items;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/PlanUpdateContent$Items;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEntries ()Ljava/util/List;
+	public fun getPlanId-RbgNvSo ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/PlanUpdateContent$Items$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/PlanUpdateContent$Items$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/PlanUpdateContent$Items;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/PlanUpdateContent$Items;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanUpdateContent$Items$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanUpdateContent$Markdown : com/agentclientprotocol/model/v2/PlanUpdateContent, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/PlanUpdateContent$Markdown$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-RbgNvSo ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy-THESmG4 (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/PlanUpdateContent$Markdown;
+	public static synthetic fun copy-THESmG4$default (Lcom/agentclientprotocol/model/v2/PlanUpdateContent$Markdown;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/PlanUpdateContent$Markdown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Ljava/lang/String;
+	public fun getPlanId-RbgNvSo ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/PlanUpdateContent$Markdown$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/PlanUpdateContent$Markdown$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/PlanUpdateContent$Markdown;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/PlanUpdateContent$Markdown;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanUpdateContent$Markdown$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/PlanUpdateContent$Unknown : com/agentclientprotocol/model/v2/PlanUpdateContent {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2-RbgNvSo ()Ljava/lang/String;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy-8plRgmQ (Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lcom/agentclientprotocol/model/v2/PlanUpdateContent$Unknown;
+	public static synthetic fun copy-8plRgmQ$default (Lcom/agentclientprotocol/model/v2/PlanUpdateContent$Unknown;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/PlanUpdateContent$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getPlanId-RbgNvSo ()Ljava/lang/String;
+	public final fun getRawJson ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/RequestPermissionOutcome {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/RequestPermissionOutcome$Companion;
+}
+
+public final class com/agentclientprotocol/model/v2/RequestPermissionOutcome$Cancelled : com/agentclientprotocol/model/v2/RequestPermissionOutcome {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/RequestPermissionOutcome$Cancelled;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/RequestPermissionOutcome$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/RequestPermissionOutcome$Selected : com/agentclientprotocol/model/v2/RequestPermissionOutcome, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/RequestPermissionOutcome$Selected$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-w2So5B0 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy-otG_NdU (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/RequestPermissionOutcome$Selected;
+	public static synthetic fun copy-otG_NdU$default (Lcom/agentclientprotocol/model/v2/RequestPermissionOutcome$Selected;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/RequestPermissionOutcome$Selected;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOptionId-w2So5B0 ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/RequestPermissionOutcome$Selected$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/RequestPermissionOutcome$Selected$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/RequestPermissionOutcome$Selected;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/RequestPermissionOutcome$Selected;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/RequestPermissionOutcome$Selected$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/RequestPermissionOutcome$Unknown : com/agentclientprotocol/model/v2/RequestPermissionOutcome {
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lcom/agentclientprotocol/model/v2/RequestPermissionOutcome$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/RequestPermissionOutcome$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/RequestPermissionOutcome$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOutcome ()Ljava/lang/String;
+	public final fun getRawJson ()Lkotlinx/serialization/json/JsonObject;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/Role {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/Role$Companion;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/Role$Assistant : com/agentclientprotocol/model/v2/Role {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/Role$Assistant;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/Role$Companion {
+	public final fun extension (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/Role$Unknown;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/Role$Unknown : com/agentclientprotocol/model/v2/Role {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/Role$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/Role$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/Role$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/Role$User : com/agentclientprotocol/model/v2/Role {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/Role$User;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/SessionConfigKind {
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigKind$Boolean : com/agentclientprotocol/model/v2/SessionConfigKind {
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lcom/agentclientprotocol/model/v2/SessionConfigKind$Boolean;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionConfigKind$Boolean;ZILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionConfigKind$Boolean;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCurrentValue ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigKind$Select : com/agentclientprotocol/model/v2/SessionConfigKind {
+	public synthetic fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/SessionConfigSelectOptions;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-cDIbsdA ()Ljava/lang/String;
+	public final fun component2 ()Lcom/agentclientprotocol/model/v2/SessionConfigSelectOptions;
+	public final fun copy-u2B9kdw (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/SessionConfigSelectOptions;)Lcom/agentclientprotocol/model/v2/SessionConfigKind$Select;
+	public static synthetic fun copy-u2B9kdw$default (Lcom/agentclientprotocol/model/v2/SessionConfigKind$Select;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/SessionConfigSelectOptions;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionConfigKind$Select;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCurrentValue-cDIbsdA ()Ljava/lang/String;
+	public final fun getOptions ()Lcom/agentclientprotocol/model/v2/SessionConfigSelectOptions;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigKind$Unknown : com/agentclientprotocol/model/v2/SessionConfigKind {
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lcom/agentclientprotocol/model/v2/SessionConfigKind$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionConfigKind$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionConfigKind$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFields ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigOption : com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/SessionConfigOption$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/SessionConfigOptionCategory;Lcom/agentclientprotocol/model/v2/SessionConfigKind;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/SessionConfigOptionCategory;Lcom/agentclientprotocol/model/v2/SessionConfigKind;Lkotlinx/serialization/json/JsonElement;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-2Q23AbI ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/agentclientprotocol/model/v2/SessionConfigOptionCategory;
+	public final fun component5 ()Lcom/agentclientprotocol/model/v2/SessionConfigKind;
+	public final fun component6 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy-gDTkyeM (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/SessionConfigOptionCategory;Lcom/agentclientprotocol/model/v2/SessionConfigKind;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/SessionConfigOption;
+	public static synthetic fun copy-gDTkyeM$default (Lcom/agentclientprotocol/model/v2/SessionConfigOption;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/SessionConfigOptionCategory;Lcom/agentclientprotocol/model/v2/SessionConfigKind;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionConfigOption;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCategory ()Lcom/agentclientprotocol/model/v2/SessionConfigOptionCategory;
+	public final fun getConfigId-2Q23AbI ()Ljava/lang/String;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getKind ()Lcom/agentclientprotocol/model/v2/SessionConfigKind;
+	public final fun getName ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigOption$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/agentclientprotocol/model/v2/SessionConfigOptionCategory {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/SessionConfigOptionCategory$Companion;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigOptionCategory$Companion {
+	public final fun extension (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/SessionConfigOptionCategory$Unknown;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigOptionCategory$Mode : com/agentclientprotocol/model/v2/SessionConfigOptionCategory {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/SessionConfigOptionCategory$Mode;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigOptionCategory$Model : com/agentclientprotocol/model/v2/SessionConfigOptionCategory {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/SessionConfigOptionCategory$Model;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigOptionCategory$ModelConfig : com/agentclientprotocol/model/v2/SessionConfigOptionCategory {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/SessionConfigOptionCategory$ModelConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigOptionCategory$ThoughtLevel : com/agentclientprotocol/model/v2/SessionConfigOptionCategory {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/SessionConfigOptionCategory$ThoughtLevel;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigOptionCategory$Unknown : com/agentclientprotocol/model/v2/SessionConfigOptionCategory {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/SessionConfigOptionCategory$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionConfigOptionCategory$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionConfigOptionCategory$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/SessionConfigOptionValue {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue$Companion;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigOptionValue$Boolean : com/agentclientprotocol/model/v2/SessionConfigOptionValue {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue$Boolean$Companion;
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue$Boolean;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue$Boolean;ZILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue$Boolean;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/SessionConfigOptionValue$Boolean$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue$Boolean$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue$Boolean;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue$Boolean;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigOptionValue$Boolean$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigOptionValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigOptionValue$Id : com/agentclientprotocol/model/v2/SessionConfigOptionValue {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue$Id$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-cDIbsdA ()Ljava/lang/String;
+	public final fun copy-Ly9kg54 (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue$Id;
+	public static synthetic fun copy-Ly9kg54$default (Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue$Id;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue$Id;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue-cDIbsdA ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/SessionConfigOptionValue$Id$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue$Id$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue$Id;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue$Id;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigOptionValue$Id$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigOptionValue$Unknown : com/agentclientprotocol/model/v2/SessionConfigOptionValue {
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonObject;)Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRawJson ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getValue ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigSelectGroup : com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/SessionConfigSelectGroup$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-qNdPhfw ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy-OpfNXNI (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/SessionConfigSelectGroup;
+	public static synthetic fun copy-OpfNXNI$default (Lcom/agentclientprotocol/model/v2/SessionConfigSelectGroup;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionConfigSelectGroup;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGroupId-qNdPhfw ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Ljava/util/List;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/SessionConfigSelectGroup$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/SessionConfigSelectGroup$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/SessionConfigSelectGroup;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/SessionConfigSelectGroup;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigSelectGroup$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/agentclientprotocol/model/v2/SessionConfigSelectOptions {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/SessionConfigSelectOptions$Companion;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigSelectOptions$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigSelectOptions$Grouped : com/agentclientprotocol/model/v2/SessionConfigSelectOptions {
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/agentclientprotocol/model/v2/SessionConfigSelectOptions$Grouped;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionConfigSelectOptions$Grouped;Ljava/util/List;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionConfigSelectOptions$Grouped;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGroups ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionConfigSelectOptions$Ungrouped : com/agentclientprotocol/model/v2/SessionConfigSelectOptions {
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/agentclientprotocol/model/v2/SessionConfigSelectOptions$Ungrouped;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionConfigSelectOptions$Ungrouped;Ljava/util/List;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionConfigSelectOptions$Ungrouped;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOptions ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionInfoUpdate {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/SessionInfoUpdate$Companion;
+	public fun <init> ()V
+	public fun <init> (Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;)V
+	public synthetic fun <init> (Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun component2 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun component3 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;)Lcom/agentclientprotocol/model/v2/SessionInfoUpdate;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionInfoUpdate;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionInfoUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTitle ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun getUpdatedAt ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun get_meta ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionInfoUpdate$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/agentclientprotocol/model/v2/SessionUpdate {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/SessionUpdate$Companion;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionUpdate$AgentMessage : com/agentclientprotocol/model/v2/SessionUpdate {
+	public fun <init> (Lcom/agentclientprotocol/model/v2/AgentMessage;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/AgentMessage;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/AgentMessage;)Lcom/agentclientprotocol/model/v2/SessionUpdate$AgentMessage;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$AgentMessage;Lcom/agentclientprotocol/model/v2/AgentMessage;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$AgentMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Lcom/agentclientprotocol/model/v2/AgentMessage;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionUpdate$AgentMessageChunk : com/agentclientprotocol/model/v2/SessionUpdate {
+	public fun <init> (Lcom/agentclientprotocol/model/v2/ContentChunk;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/ContentChunk;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/ContentChunk;)Lcom/agentclientprotocol/model/v2/SessionUpdate$AgentMessageChunk;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$AgentMessageChunk;Lcom/agentclientprotocol/model/v2/ContentChunk;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$AgentMessageChunk;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChunk ()Lcom/agentclientprotocol/model/v2/ContentChunk;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionUpdate$AgentThought : com/agentclientprotocol/model/v2/SessionUpdate {
+	public fun <init> (Lcom/agentclientprotocol/model/v2/AgentThought;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/AgentThought;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/AgentThought;)Lcom/agentclientprotocol/model/v2/SessionUpdate$AgentThought;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$AgentThought;Lcom/agentclientprotocol/model/v2/AgentThought;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$AgentThought;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getThought ()Lcom/agentclientprotocol/model/v2/AgentThought;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionUpdate$AgentThoughtChunk : com/agentclientprotocol/model/v2/SessionUpdate {
+	public fun <init> (Lcom/agentclientprotocol/model/v2/ContentChunk;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/ContentChunk;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/ContentChunk;)Lcom/agentclientprotocol/model/v2/SessionUpdate$AgentThoughtChunk;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$AgentThoughtChunk;Lcom/agentclientprotocol/model/v2/ContentChunk;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$AgentThoughtChunk;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChunk ()Lcom/agentclientprotocol/model/v2/ContentChunk;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionUpdate$AvailableCommandsUpdate : com/agentclientprotocol/model/v2/SessionUpdate {
+	public fun <init> (Lcom/agentclientprotocol/model/v2/AvailableCommandsUpdate;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/AvailableCommandsUpdate;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/AvailableCommandsUpdate;)Lcom/agentclientprotocol/model/v2/SessionUpdate$AvailableCommandsUpdate;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$AvailableCommandsUpdate;Lcom/agentclientprotocol/model/v2/AvailableCommandsUpdate;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$AvailableCommandsUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUpdate ()Lcom/agentclientprotocol/model/v2/AvailableCommandsUpdate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionUpdate$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionUpdate$ConfigOptionUpdate : com/agentclientprotocol/model/v2/SessionUpdate {
+	public fun <init> (Lcom/agentclientprotocol/model/v2/ConfigOptionUpdate;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/ConfigOptionUpdate;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/ConfigOptionUpdate;)Lcom/agentclientprotocol/model/v2/SessionUpdate$ConfigOptionUpdate;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$ConfigOptionUpdate;Lcom/agentclientprotocol/model/v2/ConfigOptionUpdate;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$ConfigOptionUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUpdate ()Lcom/agentclientprotocol/model/v2/ConfigOptionUpdate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionUpdate$PlanRemoved : com/agentclientprotocol/model/v2/SessionUpdate {
+	public fun <init> (Lcom/agentclientprotocol/model/v2/PlanRemoved;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/PlanRemoved;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/PlanRemoved;)Lcom/agentclientprotocol/model/v2/SessionUpdate$PlanRemoved;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$PlanRemoved;Lcom/agentclientprotocol/model/v2/PlanRemoved;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$PlanRemoved;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRemoved ()Lcom/agentclientprotocol/model/v2/PlanRemoved;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionUpdate$PlanUpdate : com/agentclientprotocol/model/v2/SessionUpdate {
+	public fun <init> (Lcom/agentclientprotocol/model/v2/PlanUpdate;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/PlanUpdate;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/PlanUpdate;)Lcom/agentclientprotocol/model/v2/SessionUpdate$PlanUpdate;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$PlanUpdate;Lcom/agentclientprotocol/model/v2/PlanUpdate;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$PlanUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUpdate ()Lcom/agentclientprotocol/model/v2/PlanUpdate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionUpdate$SessionInfoUpdate : com/agentclientprotocol/model/v2/SessionUpdate {
+	public fun <init> (Lcom/agentclientprotocol/model/v2/SessionInfoUpdate;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/SessionInfoUpdate;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/SessionInfoUpdate;)Lcom/agentclientprotocol/model/v2/SessionUpdate$SessionInfoUpdate;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$SessionInfoUpdate;Lcom/agentclientprotocol/model/v2/SessionInfoUpdate;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$SessionInfoUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUpdate ()Lcom/agentclientprotocol/model/v2/SessionInfoUpdate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionUpdate$StateUpdate : com/agentclientprotocol/model/v2/SessionUpdate {
+	public fun <init> (Lcom/agentclientprotocol/model/v2/StateUpdate;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/StateUpdate;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/StateUpdate;)Lcom/agentclientprotocol/model/v2/SessionUpdate$StateUpdate;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$StateUpdate;Lcom/agentclientprotocol/model/v2/StateUpdate;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$StateUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getState ()Lcom/agentclientprotocol/model/v2/StateUpdate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionUpdate$ToolCallContentChunk : com/agentclientprotocol/model/v2/SessionUpdate {
+	public fun <init> (Lcom/agentclientprotocol/model/v2/ToolCallContentChunk;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/ToolCallContentChunk;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/ToolCallContentChunk;)Lcom/agentclientprotocol/model/v2/SessionUpdate$ToolCallContentChunk;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$ToolCallContentChunk;Lcom/agentclientprotocol/model/v2/ToolCallContentChunk;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$ToolCallContentChunk;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChunk ()Lcom/agentclientprotocol/model/v2/ToolCallContentChunk;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionUpdate$ToolCallUpdate : com/agentclientprotocol/model/v2/SessionUpdate {
+	public fun <init> (Lcom/agentclientprotocol/model/v2/ToolCallUpdate;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/ToolCallUpdate;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/ToolCallUpdate;)Lcom/agentclientprotocol/model/v2/SessionUpdate$ToolCallUpdate;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$ToolCallUpdate;Lcom/agentclientprotocol/model/v2/ToolCallUpdate;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$ToolCallUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUpdate ()Lcom/agentclientprotocol/model/v2/ToolCallUpdate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionUpdate$Unknown : com/agentclientprotocol/model/v2/SessionUpdate {
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lcom/agentclientprotocol/model/v2/SessionUpdate$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRawJson ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getSessionUpdate ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionUpdate$UsageUpdate : com/agentclientprotocol/model/v2/SessionUpdate {
+	public fun <init> (Lcom/agentclientprotocol/model/v2/UsageUpdate;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/UsageUpdate;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/UsageUpdate;)Lcom/agentclientprotocol/model/v2/SessionUpdate$UsageUpdate;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$UsageUpdate;Lcom/agentclientprotocol/model/v2/UsageUpdate;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$UsageUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUpdate ()Lcom/agentclientprotocol/model/v2/UsageUpdate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionUpdate$UserMessage : com/agentclientprotocol/model/v2/SessionUpdate {
+	public fun <init> (Lcom/agentclientprotocol/model/v2/UserMessage;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/UserMessage;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/UserMessage;)Lcom/agentclientprotocol/model/v2/SessionUpdate$UserMessage;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$UserMessage;Lcom/agentclientprotocol/model/v2/UserMessage;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$UserMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Lcom/agentclientprotocol/model/v2/UserMessage;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionUpdate$UserMessageChunk : com/agentclientprotocol/model/v2/SessionUpdate {
+	public fun <init> (Lcom/agentclientprotocol/model/v2/ContentChunk;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/ContentChunk;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/ContentChunk;)Lcom/agentclientprotocol/model/v2/SessionUpdate$UserMessageChunk;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$UserMessageChunk;Lcom/agentclientprotocol/model/v2/ContentChunk;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$UserMessageChunk;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChunk ()Lcom/agentclientprotocol/model/v2/ContentChunk;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/StateUpdate {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/StateUpdate$Companion;
+}
+
+public final class com/agentclientprotocol/model/v2/StateUpdate$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/StateUpdate$Idle : com/agentclientprotocol/model/v2/StateUpdate, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/StateUpdate$Idle$Companion;
+	public fun <init> ()V
+	public fun <init> (Lcom/agentclientprotocol/model/v2/StopReason;Lcom/agentclientprotocol/model/Usage;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Lcom/agentclientprotocol/model/v2/StopReason;Lcom/agentclientprotocol/model/Usage;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/StopReason;
+	public final fun component2 ()Lcom/agentclientprotocol/model/Usage;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/StopReason;Lcom/agentclientprotocol/model/Usage;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/StateUpdate$Idle;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/StateUpdate$Idle;Lcom/agentclientprotocol/model/v2/StopReason;Lcom/agentclientprotocol/model/Usage;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/StateUpdate$Idle;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStopReason ()Lcom/agentclientprotocol/model/v2/StopReason;
+	public final fun getUsage ()Lcom/agentclientprotocol/model/Usage;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/StateUpdate$Idle$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/StateUpdate$Idle$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/StateUpdate$Idle;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/StateUpdate$Idle;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/StateUpdate$Idle$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/StateUpdate$RequiresAction : com/agentclientprotocol/model/v2/StateUpdate, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/StateUpdate$RequiresAction$Companion;
+	public fun <init> ()V
+	public fun <init> (Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/StateUpdate$RequiresAction;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/StateUpdate$RequiresAction;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/StateUpdate$RequiresAction;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/StateUpdate$RequiresAction$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/StateUpdate$RequiresAction$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/StateUpdate$RequiresAction;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/StateUpdate$RequiresAction;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/StateUpdate$RequiresAction$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/StateUpdate$Running : com/agentclientprotocol/model/v2/StateUpdate, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/StateUpdate$Running$Companion;
+	public fun <init> ()V
+	public fun <init> (Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/StateUpdate$Running;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/StateUpdate$Running;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/StateUpdate$Running;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/StateUpdate$Running$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/StateUpdate$Running$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/StateUpdate$Running;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/StateUpdate$Running;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/StateUpdate$Running$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/StateUpdate$Unknown : com/agentclientprotocol/model/v2/StateUpdate {
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lcom/agentclientprotocol/model/v2/StateUpdate$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/StateUpdate$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/StateUpdate$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRawJson ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getState ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/StopReason {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/StopReason$Companion;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/StopReason$Cancelled : com/agentclientprotocol/model/v2/StopReason {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/StopReason$Cancelled;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/StopReason$Companion {
+	public final fun extension (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/StopReason$Unknown;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/StopReason$EndTurn : com/agentclientprotocol/model/v2/StopReason {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/StopReason$EndTurn;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/StopReason$MaxTokens : com/agentclientprotocol/model/v2/StopReason {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/StopReason$MaxTokens;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/StopReason$MaxTurnRequests : com/agentclientprotocol/model/v2/StopReason {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/StopReason$MaxTurnRequests;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/StopReason$Refusal : com/agentclientprotocol/model/v2/StopReason {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/StopReason$Refusal;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/StopReason$Unknown : com/agentclientprotocol/model/v2/StopReason {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/StopReason$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/StopReason$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/StopReason$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/StringFormat {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/StringFormat$Companion;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/StringFormat$Companion {
+	public final fun extension (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/StringFormat$Unknown;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/StringFormat$Date : com/agentclientprotocol/model/v2/StringFormat {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/StringFormat$Date;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/StringFormat$DateTime : com/agentclientprotocol/model/v2/StringFormat {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/StringFormat$DateTime;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/StringFormat$Email : com/agentclientprotocol/model/v2/StringFormat {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/StringFormat$Email;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/StringFormat$Unknown : com/agentclientprotocol/model/v2/StringFormat {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/StringFormat$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/StringFormat$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/StringFormat$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/StringFormat$Uri : com/agentclientprotocol/model/v2/StringFormat {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/StringFormat$Uri;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class com/agentclientprotocol/model/v2/ToolCallContent {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ToolCallContent$Companion;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolCallContent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolCallContent$Content : com/agentclientprotocol/model/v2/ToolCallContent, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ToolCallContent$Content$Companion;
+	public fun <init> (Lcom/agentclientprotocol/model/v2/ContentBlock;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Lcom/agentclientprotocol/model/v2/ContentBlock;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/ContentBlock;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/ContentBlock;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/ToolCallContent$Content;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ToolCallContent$Content;Lcom/agentclientprotocol/model/v2/ContentBlock;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ToolCallContent$Content;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Lcom/agentclientprotocol/model/v2/ContentBlock;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/ToolCallContent$Content$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ToolCallContent$Content$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/ToolCallContent$Content;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/ToolCallContent$Content;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolCallContent$Content$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolCallContent$Diff : com/agentclientprotocol/model/v2/ToolCallContent, com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ToolCallContent$Diff$Companion;
+	public fun <init> (Ljava/util/List;Lcom/agentclientprotocol/model/v2/DiffPatch;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/util/List;Lcom/agentclientprotocol/model/v2/DiffPatch;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lcom/agentclientprotocol/model/v2/DiffPatch;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/util/List;Lcom/agentclientprotocol/model/v2/DiffPatch;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/ToolCallContent$Diff;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ToolCallContent$Diff;Ljava/util/List;Lcom/agentclientprotocol/model/v2/DiffPatch;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ToolCallContent$Diff;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChanges ()Ljava/util/List;
+	public final fun getPatch ()Lcom/agentclientprotocol/model/v2/DiffPatch;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/ToolCallContent$Diff$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ToolCallContent$Diff$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/ToolCallContent$Diff;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/ToolCallContent$Diff;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolCallContent$Diff$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolCallContent$Unknown : com/agentclientprotocol/model/v2/ToolCallContent {
+	public fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun copy (Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;)Lcom/agentclientprotocol/model/v2/ToolCallContent$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ToolCallContent$Unknown;Ljava/lang/String;Lkotlinx/serialization/json/JsonObject;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ToolCallContent$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRawJson ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolCallContentChunk : com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ToolCallContentChunk$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/ToolCallContent;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/ToolCallContent;Lkotlinx/serialization/json/JsonElement;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-DimCYko ()Ljava/lang/String;
+	public final fun component2 ()Lcom/agentclientprotocol/model/v2/ToolCallContent;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy-dlzL_xY (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/ToolCallContent;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/ToolCallContentChunk;
+	public static synthetic fun copy-dlzL_xY$default (Lcom/agentclientprotocol/model/v2/ToolCallContentChunk;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/ToolCallContent;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ToolCallContentChunk;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Lcom/agentclientprotocol/model/v2/ToolCallContent;
+	public final fun getToolCallId-DimCYko ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/ToolCallContentChunk$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ToolCallContentChunk$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/ToolCallContentChunk;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/ToolCallContentChunk;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolCallContentChunk$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/agentclientprotocol/model/v2/ToolCallStatus {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ToolCallStatus$Companion;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolCallStatus$Companion {
+	public final fun extension (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/ToolCallStatus$Unknown;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolCallStatus$Completed : com/agentclientprotocol/model/v2/ToolCallStatus {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ToolCallStatus$Completed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolCallStatus$Failed : com/agentclientprotocol/model/v2/ToolCallStatus {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ToolCallStatus$Failed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolCallStatus$InProgress : com/agentclientprotocol/model/v2/ToolCallStatus {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ToolCallStatus$InProgress;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolCallStatus$Pending : com/agentclientprotocol/model/v2/ToolCallStatus {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ToolCallStatus$Pending;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolCallStatus$Unknown : com/agentclientprotocol/model/v2/ToolCallStatus {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/ToolCallStatus$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ToolCallStatus$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ToolCallStatus$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolCallUpdate {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ToolCallUpdate$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun applyUpdate (Lcom/agentclientprotocol/model/v2/ToolCallUpdate;)Lcom/agentclientprotocol/model/v2/ToolCallUpdate;
+	public final fun component1-DimCYko ()Ljava/lang/String;
+	public final fun component2 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun component3 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun component4 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun component5 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun component6 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun component7 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun component8 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun component9 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun copy-IATGWB8 (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;)Lcom/agentclientprotocol/model/v2/ToolCallUpdate;
+	public static synthetic fun copy-IATGWB8$default (Lcom/agentclientprotocol/model/v2/ToolCallUpdate;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ToolCallUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun getKind ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun getLocations ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun getRawInput ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun getRawOutput ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun getStatus ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun getTitle ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun getToolCallId-DimCYko ()Ljava/lang/String;
+	public final fun get_meta ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolCallUpdate$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/agentclientprotocol/model/v2/ToolKind {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/ToolKind$Companion;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolKind$Companion {
+	public final fun extension (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/ToolKind$Unknown;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolKind$Delete : com/agentclientprotocol/model/v2/ToolKind {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ToolKind$Delete;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolKind$Edit : com/agentclientprotocol/model/v2/ToolKind {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ToolKind$Edit;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolKind$Execute : com/agentclientprotocol/model/v2/ToolKind {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ToolKind$Execute;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolKind$Fetch : com/agentclientprotocol/model/v2/ToolKind {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ToolKind$Fetch;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolKind$Move : com/agentclientprotocol/model/v2/ToolKind {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ToolKind$Move;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolKind$Other : com/agentclientprotocol/model/v2/ToolKind {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ToolKind$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolKind$Read : com/agentclientprotocol/model/v2/ToolKind {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ToolKind$Read;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolKind$Search : com/agentclientprotocol/model/v2/ToolKind {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ToolKind$Search;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolKind$SwitchMode : com/agentclientprotocol/model/v2/ToolKind {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ToolKind$SwitchMode;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolKind$Think : com/agentclientprotocol/model/v2/ToolKind {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/ToolKind$Think;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/ToolKind$Unknown : com/agentclientprotocol/model/v2/ToolKind {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/ToolKind$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/ToolKind$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/ToolKind$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/UsageUpdate : com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/UsageUpdate$Companion;
+	public fun <init> (JJLcom/agentclientprotocol/model/Cost;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (JJLcom/agentclientprotocol/model/Cost;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun component3 ()Lcom/agentclientprotocol/model/Cost;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (JJLcom/agentclientprotocol/model/Cost;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/UsageUpdate;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/UsageUpdate;JJLcom/agentclientprotocol/model/Cost;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/UsageUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCost ()Lcom/agentclientprotocol/model/Cost;
+	public final fun getSize ()J
+	public final fun getUsed ()J
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/UsageUpdate$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/UsageUpdate$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/UsageUpdate;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/UsageUpdate;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/UsageUpdate$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/UserMessage {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/UserMessage$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-Q0JOWoQ ()Ljava/lang/String;
+	public final fun component2 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun component3 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun copy-jGZKPAM (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;)Lcom/agentclientprotocol/model/v2/UserMessage;
+	public static synthetic fun copy-jGZKPAM$default (Lcom/agentclientprotocol/model/v2/UserMessage;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/UserMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun getMessageId-Q0JOWoQ ()Ljava/lang/String;
+	public final fun get_meta ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/UserMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/conversion/ContentConversionsKt {
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/Annotations;)Lcom/agentclientprotocol/model/Annotations;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/ContentBlock;)Lcom/agentclientprotocol/model/ContentBlock;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource;)Lcom/agentclientprotocol/model/EmbeddedResourceResource;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/Annotations;)Lcom/agentclientprotocol/model/v2/Annotations;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/ContentBlock;)Lcom/agentclientprotocol/model/v2/ContentBlock;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/EmbeddedResourceResource;)Lcom/agentclientprotocol/model/v2/EmbeddedResourceResource;
+}
+
+public final class com/agentclientprotocol/model/v2/conversion/ElicitationConversionsKt {
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/ElicitationAction;)Lcom/agentclientprotocol/model/ElicitationAction;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema;)Lcom/agentclientprotocol/model/ElicitationPropertySchema;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/ElicitationSchema;)Lcom/agentclientprotocol/model/ElicitationSchema;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/MultiSelectItems;)Lcom/agentclientprotocol/model/MultiSelectItems;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/StringFormat;)Lcom/agentclientprotocol/model/StringFormat;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/ElicitationAction;)Lcom/agentclientprotocol/model/v2/ElicitationAction;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/ElicitationPropertySchema;)Lcom/agentclientprotocol/model/v2/ElicitationPropertySchema;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/ElicitationSchema;)Lcom/agentclientprotocol/model/v2/ElicitationSchema;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/MultiSelectItems;)Lcom/agentclientprotocol/model/v2/MultiSelectItems;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/StringFormat;)Lcom/agentclientprotocol/model/v2/StringFormat;
+}
+
+public final class com/agentclientprotocol/model/v2/conversion/NesConversionsKt {
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/NesDiagnosticSeverity;)Lcom/agentclientprotocol/model/NesDiagnosticSeverity;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/NesRejectReason;)Lcom/agentclientprotocol/model/NesRejectReason;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/NesSuggestion;)Lcom/agentclientprotocol/model/NesSuggestion;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/NesTriggerKind;)Lcom/agentclientprotocol/model/NesTriggerKind;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/NesDiagnosticSeverity;)Lcom/agentclientprotocol/model/v2/NesDiagnosticSeverity;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/NesRejectReason;)Lcom/agentclientprotocol/model/v2/NesRejectReason;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/NesSuggestion;)Lcom/agentclientprotocol/model/v2/NesSuggestion;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/NesTriggerKind;)Lcom/agentclientprotocol/model/v2/NesTriggerKind;
+}
+
+public final class com/agentclientprotocol/model/v2/conversion/PlanConversionsKt {
+	public static final fun getLEGACY_V1_PLAN_ID ()Ljava/lang/String;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/PlanEntry;)Lcom/agentclientprotocol/model/PlanEntry;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/PlanEntryPriority;)Lcom/agentclientprotocol/model/PlanEntryPriority;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/PlanEntryStatus;)Lcom/agentclientprotocol/model/PlanEntryStatus;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/PlanRemoved;)Lcom/agentclientprotocol/model/SessionUpdate$PlanRemoved;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/PlanUpdate;)Lcom/agentclientprotocol/model/SessionUpdate;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/PlanEntry;)Lcom/agentclientprotocol/model/v2/PlanEntry;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/PlanEntryPriority;)Lcom/agentclientprotocol/model/v2/PlanEntryPriority;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/PlanEntryStatus;)Lcom/agentclientprotocol/model/v2/PlanEntryStatus;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/SessionUpdate$PlanRemoved;)Lcom/agentclientprotocol/model/v2/PlanRemoved;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/SessionUpdate$PlanUpdate;)Lcom/agentclientprotocol/model/v2/PlanUpdate;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/SessionUpdate$PlanUpdateV2;)Lcom/agentclientprotocol/model/v2/PlanUpdate;
+}
+
+public final class com/agentclientprotocol/model/v2/conversion/ProtocolConversionException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class com/agentclientprotocol/model/v2/conversion/RequestsConversionsKt {
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/AuthMethod;)Lcom/agentclientprotocol/model/AuthMethod;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/LlmProtocol;)Ljava/lang/String;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/McpServer;)Lcom/agentclientprotocol/model/McpServer;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/PermissionOptionKind;)Lcom/agentclientprotocol/model/PermissionOptionKind;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/RequestPermissionOutcome;)Lcom/agentclientprotocol/model/RequestPermissionOutcome;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/StopReason;)Lcom/agentclientprotocol/model/StopReason;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/AuthMethod;)Lcom/agentclientprotocol/model/v2/AuthMethod;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/McpServer;)Lcom/agentclientprotocol/model/v2/McpServer;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/PermissionOptionKind;)Lcom/agentclientprotocol/model/v2/PermissionOptionKind;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/RequestPermissionOutcome;)Lcom/agentclientprotocol/model/v2/RequestPermissionOutcome;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/StopReason;)Lcom/agentclientprotocol/model/v2/StopReason;
+	public static final fun toV2-C7TfUKM (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/LlmProtocol;
+}
+
+public final class com/agentclientprotocol/model/v2/conversion/SessionConfigConversionsKt {
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/SessionConfigOption;)Lcom/agentclientprotocol/model/SessionConfigOption;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/SessionConfigOptionCategory;)Ljava/lang/String;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue;)Lcom/agentclientprotocol/model/SessionConfigOptionValue;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/SessionConfigSelectGroup;)Lcom/agentclientprotocol/model/SessionConfigSelectGroup;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/SessionConfigSelectOptions;)Lcom/agentclientprotocol/model/SessionConfigSelectOptions;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/SessionConfigOption;)Lcom/agentclientprotocol/model/v2/SessionConfigOption;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/SessionConfigOptionValue;)Lcom/agentclientprotocol/model/v2/SessionConfigOptionValue;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/SessionConfigSelectGroup;)Lcom/agentclientprotocol/model/v2/SessionConfigSelectGroup;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/SessionConfigSelectOptions;)Lcom/agentclientprotocol/model/v2/SessionConfigSelectOptions;
+	public static final fun toV2-Bp9ySYI (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/SessionConfigOptionCategory;
+}
+
+public final class com/agentclientprotocol/model/v2/conversion/SessionUpdateConversionsKt {
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/AvailableCommand;)Lcom/agentclientprotocol/model/AvailableCommand;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/AvailableCommandInput;)Lcom/agentclientprotocol/model/AvailableCommandInput;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/AvailableCommandsUpdate;)Lcom/agentclientprotocol/model/SessionUpdate$AvailableCommandsUpdate;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/ConfigOptionUpdate;)Lcom/agentclientprotocol/model/SessionUpdate$ConfigOptionUpdate;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/SessionInfoUpdate;)Lcom/agentclientprotocol/model/SessionUpdate$SessionInfoUpdate;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/SessionUpdate;)Ljava/util/List;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/UsageUpdate;)Lcom/agentclientprotocol/model/SessionUpdate$UsageUpdate;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/AvailableCommand;)Lcom/agentclientprotocol/model/v2/AvailableCommand;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/AvailableCommandInput;)Lcom/agentclientprotocol/model/v2/AvailableCommandInput;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/SessionUpdate$AvailableCommandsUpdate;)Lcom/agentclientprotocol/model/v2/AvailableCommandsUpdate;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/SessionUpdate$ConfigOptionUpdate;)Lcom/agentclientprotocol/model/v2/ConfigOptionUpdate;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/SessionUpdate$SessionInfoUpdate;)Lcom/agentclientprotocol/model/v2/SessionInfoUpdate;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/SessionUpdate$UsageUpdate;)Lcom/agentclientprotocol/model/v2/UsageUpdate;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/SessionUpdate;)Lcom/agentclientprotocol/model/v2/SessionUpdate;
+}
+
+public final class com/agentclientprotocol/model/v2/conversion/ToolCallConversionsKt {
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/ToolCallStatus;)Lcom/agentclientprotocol/model/ToolCallStatus;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/ToolCallUpdate;)Lcom/agentclientprotocol/model/SessionUpdate$ToolCallUpdate;
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/ToolKind;)Lcom/agentclientprotocol/model/ToolKind;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/SessionUpdate$ToolCall;)Lcom/agentclientprotocol/model/v2/ToolCallUpdate;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/SessionUpdate$ToolCallUpdate;)Lcom/agentclientprotocol/model/v2/ToolCallUpdate;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/ToolCallStatus;)Lcom/agentclientprotocol/model/v2/ToolCallStatus;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/ToolKind;)Lcom/agentclientprotocol/model/v2/ToolKind;
+}
+
+public final class com/agentclientprotocol/model/v2/conversion/TypesConversionsKt {
+	public static final fun toV1 (Lcom/agentclientprotocol/model/v2/Role;)Lcom/agentclientprotocol/model/Role;
+	public static final fun toV2 (Lcom/agentclientprotocol/model/Role;)Lcom/agentclientprotocol/model/v2/Role;
+}
+
 public final class com/agentclientprotocol/rpc/JsonRpcError {
 	public static final field Companion Lcom/agentclientprotocol/rpc/JsonRpcError$Companion;
 	public fun <init> (ILjava/lang/String;Lkotlinx/serialization/json/JsonElement;)V

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/Content.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/Content.kt
@@ -1,0 +1,312 @@
+@file:Suppress("unused")
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.AcpWithMeta
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * Theme an icon is designed for.
+ *
+ * This is an open enum: unrecognized wire values deserialize to [Unknown] instead of
+ * failing, so newer ACP variants and `_`-prefixed extensions degrade gracefully.
+ */
+@UnstableApi
+@Serializable(with = IconThemeSerializer::class)
+public sealed class IconTheme {
+    /**
+     * The wire-format string for this theme.
+     */
+    public abstract val value: String
+
+    /**
+     * Icon designed for light backgrounds.
+     */
+    public data object Light : IconTheme() {
+        override val value: String = "light"
+    }
+
+    /**
+     * Icon designed for dark backgrounds.
+     */
+    public data object Dark : IconTheme() {
+        override val value: String = "dark"
+    }
+
+    /**
+     * Custom or future icon theme.
+     *
+     * Values beginning with `_` are reserved for implementation-specific extensions.
+     * Unknown values that do not begin with `_` are reserved for future ACP variants
+     * and MUST NOT be treated as custom extensions.
+     *
+     * Receivers that cannot act on an unknown theme SHOULD preserve it when storing,
+     * replaying, proxying, or forwarding protocol data, and otherwise degrade gracefully
+     * according to the field's semantics.
+     */
+    public data class Unknown(override val value: String) : IconTheme()
+
+    public companion object {
+        /**
+         * Creates an implementation-specific extension theme.
+         *
+         * Extension values must begin with `_` — all other values are reserved for ACP,
+         * including future ACP variants.
+         *
+         * @throws IllegalArgumentException if [value] does not begin with `_`
+         */
+        public fun extension(value: String): Unknown {
+            require(value.startsWith('_')) {
+                "Extension values must begin with '_'; values without the prefix are reserved for ACP (got '$value')"
+            }
+            return Unknown(value)
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object IconThemeSerializer : OpenStringEnumSerializer<IconTheme>(
+    serialName = "com.agentclientprotocol.model.v2.IconTheme",
+    knownValues = listOf(
+        IconTheme.Light,
+        IconTheme.Dark,
+    ),
+    wireValue = IconTheme::value,
+    unknown = IconTheme::Unknown,
+)
+
+/**
+ * A sized icon that the client can display in a user interface.
+ */
+@UnstableApi
+@Serializable
+public data class Icon(
+    val src: String,
+    val mimeType: String? = null,
+    val sizes: List<String>? = null,
+    val theme: IconTheme? = null,
+)
+
+/**
+ * Optional annotations for the client. The client can use annotations to inform how
+ * objects are used or displayed.
+ *
+ * Unlike v1, [audience] uses the open v2 [Role], so unknown roles are preserved.
+ */
+@UnstableApi
+@Serializable
+public data class Annotations(
+    val audience: List<Role>? = null,
+    val priority: Double? = null,
+    val lastModified: String? = null,
+    override val _meta: JsonElement? = null,
+) : AcpWithMeta
+
+/**
+ * Resource content that can be embedded in a message.
+ *
+ * This union is discriminated by shape, not by a `type` field: a payload with `text` is
+ * text-based, a payload with `blob` is binary. It stays **closed** in v2 — without a
+ * discriminator there is nothing safe to key a fallback on.
+ */
+@UnstableApi
+@Serializable(with = EmbeddedResourceResourceSerializer::class)
+public sealed class EmbeddedResourceResource : AcpWithMeta {
+    /**
+     * Text resource contents embedded directly in the message.
+     */
+    @Serializable
+    public data class TextResourceContents(
+        val text: String,
+        val uri: String,
+        val mimeType: String? = null,
+        override val _meta: JsonElement? = null,
+    ) : EmbeddedResourceResource()
+
+    /**
+     * Binary resource contents embedded directly in the message.
+     */
+    @Serializable
+    public data class BlobResourceContents(
+        val blob: String,
+        val uri: String,
+        val mimeType: String? = null,
+        override val _meta: JsonElement? = null,
+    ) : EmbeddedResourceResource()
+}
+
+@OptIn(UnstableApi::class)
+internal object EmbeddedResourceResourceSerializer : KSerializer<EmbeddedResourceResource> {
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("com.agentclientprotocol.model.v2.EmbeddedResourceResource")
+
+    override fun serialize(encoder: Encoder, value: EmbeddedResourceResource) {
+        val jsonEncoder = encoder as JsonEncoder
+        val jsonObject = when (value) {
+            is EmbeddedResourceResource.TextResourceContents ->
+                jsonEncoder.json.encodeToJsonElement(EmbeddedResourceResource.TextResourceContents.serializer(), value)
+            is EmbeddedResourceResource.BlobResourceContents ->
+                jsonEncoder.json.encodeToJsonElement(EmbeddedResourceResource.BlobResourceContents.serializer(), value)
+        }
+        jsonEncoder.encodeJsonElement(jsonObject)
+    }
+
+    override fun deserialize(decoder: Decoder): EmbeddedResourceResource {
+        val jsonDecoder = decoder as JsonDecoder
+        val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
+        return when {
+            "text" in jsonObject -> jsonDecoder.json.decodeFromJsonElement(
+                EmbeddedResourceResource.TextResourceContents.serializer(),
+                jsonObject,
+            )
+            "blob" in jsonObject -> jsonDecoder.json.decodeFromJsonElement(
+                EmbeddedResourceResource.BlobResourceContents.serializer(),
+                jsonObject,
+            )
+            else -> throw SerializationException(
+                "Cannot determine EmbeddedResourceResource shape; expected a 'text' or 'blob' field"
+            )
+        }
+    }
+}
+
+/**
+ * Content blocks represent displayable information in the Agent Client Protocol.
+ *
+ * They provide a structured way to handle various types of user-facing content—whether
+ * it's text from language models, images for analysis, or embedded resources for context.
+ *
+ * This is an open tagged union: an unrecognized `type` discriminator deserializes to
+ * [Unknown] with the full raw JSON preserved, so newer ACP variants and `_`-prefixed
+ * extensions degrade gracefully.
+ *
+ * See protocol docs: [Content](https://agentclientprotocol.com/protocol/content)
+ */
+@UnstableApi
+@Serializable(with = ContentBlockSerializer::class)
+public sealed class ContentBlock {
+    /**
+     * Text content. May be plain text or formatted with Markdown.
+     *
+     * All agents MUST support text content blocks in prompts.
+     * Clients SHOULD render this text as Markdown.
+     */
+    @Serializable
+    public data class Text(
+        val text: String,
+        val annotations: Annotations? = null,
+        override val _meta: JsonElement? = null,
+    ) : ContentBlock(), AcpWithMeta
+
+    /**
+     * Images for visual context or analysis.
+     *
+     * Requires the `image` prompt capability when included in prompts.
+     */
+    @Serializable
+    public data class Image(
+        val data: String,
+        val mimeType: String,
+        val uri: String? = null,
+        val annotations: Annotations? = null,
+        override val _meta: JsonElement? = null,
+    ) : ContentBlock(), AcpWithMeta
+
+    /**
+     * Audio data for transcription or analysis.
+     *
+     * Requires the `audio` prompt capability when included in prompts.
+     */
+    @Serializable
+    public data class Audio(
+        val data: String,
+        val mimeType: String,
+        val annotations: Annotations? = null,
+        override val _meta: JsonElement? = null,
+    ) : ContentBlock(), AcpWithMeta
+
+    /**
+     * References to resources that the agent can access.
+     *
+     * All agents MUST support resource links in prompts.
+     */
+    @Serializable
+    public data class ResourceLink(
+        val name: String,
+        val uri: String,
+        val description: String? = null,
+        val mimeType: String? = null,
+        val size: Long? = null,
+        val title: String? = null,
+        val icons: List<Icon>? = null,
+        val annotations: Annotations? = null,
+        override val _meta: JsonElement? = null,
+    ) : ContentBlock(), AcpWithMeta
+
+    /**
+     * Complete resource contents embedded directly in the message.
+     *
+     * Preferred for including context as it avoids extra round-trips.
+     *
+     * Requires the `embeddedContext` prompt capability when included in prompts.
+     */
+    @Serializable
+    public data class Resource(
+        val resource: EmbeddedResourceResource,
+        val annotations: Annotations? = null,
+        override val _meta: JsonElement? = null,
+    ) : ContentBlock(), AcpWithMeta
+
+    /**
+     * Custom or future content block.
+     *
+     * Discriminator values beginning with `_` are reserved for implementation-specific
+     * extensions. Unknown values that do not begin with `_` are reserved for future ACP
+     * variants and MUST NOT be treated as custom extensions.
+     *
+     * [rawJson] holds the complete payload as received (including the discriminator), so
+     * re-serializing emits it byte-identically. Receivers that do not understand this
+     * content block type SHOULD preserve it when storing, replaying, proxying, or
+     * forwarding content, and otherwise ignore it or display it generically.
+     */
+    public data class Unknown(val type: String, val rawJson: JsonObject) : ContentBlock()
+}
+
+@OptIn(UnstableApi::class)
+internal object ContentBlockSerializer : OpenTaggedUnionSerializer<ContentBlock>(
+    serialName = "com.agentclientprotocol.model.v2.ContentBlock",
+    discriminatorKey = "type",
+    known = mapOf(
+        "text" to ContentBlock.Text.serializer(),
+        "image" to ContentBlock.Image.serializer(),
+        "audio" to ContentBlock.Audio.serializer(),
+        "resource_link" to ContentBlock.ResourceLink.serializer(),
+        "resource" to ContentBlock.Resource.serializer(),
+    ),
+    discriminator = { value ->
+        when (value) {
+            is ContentBlock.Text -> "text"
+            is ContentBlock.Image -> "image"
+            is ContentBlock.Audio -> "audio"
+            is ContentBlock.ResourceLink -> "resource_link"
+            is ContentBlock.Resource -> "resource"
+            is ContentBlock.Unknown -> value.type
+        }
+    },
+    unknown = ContentBlock::Unknown,
+    rawJson = { (it as? ContentBlock.Unknown)?.rawJson },
+)

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/Elicitation.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/Elicitation.kt
@@ -1,0 +1,518 @@
+@file:Suppress("unused")
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.ElicitationContentValue
+import com.agentclientprotocol.model.ElicitationId
+import com.agentclientprotocol.model.ElicitationSchemaType
+import com.agentclientprotocol.model.ElicitationScope
+import com.agentclientprotocol.model.EnumOption
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * String format types for string properties in elicitation schemas.
+ *
+ * This is an open enum: unrecognized wire values deserialize to [Unknown] instead of
+ * failing. Implementations that do not understand a format should treat it as an
+ * annotation rather than rejecting the schema.
+ */
+@UnstableApi
+@Serializable(with = StringFormatSerializer::class)
+public sealed class StringFormat {
+    /**
+     * The wire-format string for this format.
+     */
+    public abstract val value: String
+
+    /**
+     * Email address format.
+     */
+    public data object Email : StringFormat() {
+        override val value: String = "email"
+    }
+
+    /**
+     * URI format.
+     */
+    public data object Uri : StringFormat() {
+        override val value: String = "uri"
+    }
+
+    /**
+     * Date format (YYYY-MM-DD).
+     */
+    public data object Date : StringFormat() {
+        override val value: String = "date"
+    }
+
+    /**
+     * Date-time format (ISO 8601).
+     */
+    public data object DateTime : StringFormat() {
+        override val value: String = "date-time"
+    }
+
+    /**
+     * Custom or future string format.
+     *
+     * Values beginning with `_` are reserved for implementation-specific extensions.
+     * Unknown values that do not begin with `_` are reserved for future ACP variants
+     * and MUST NOT be treated as custom extensions.
+     *
+     * Receivers that cannot act on an unknown format SHOULD preserve it when storing,
+     * replaying, proxying, or forwarding protocol data, and otherwise degrade gracefully
+     * according to the field's semantics.
+     */
+    public data class Unknown(override val value: String) : StringFormat()
+
+    public companion object {
+        /**
+         * Creates an implementation-specific extension format.
+         *
+         * Extension values must begin with `_` — all other values are reserved for ACP,
+         * including future ACP variants.
+         *
+         * @throws IllegalArgumentException if [value] does not begin with `_`
+         */
+        public fun extension(value: String): Unknown {
+            require(value.startsWith('_')) {
+                "Extension values must begin with '_'; values without the prefix are reserved for ACP (got '$value')"
+            }
+            return Unknown(value)
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object StringFormatSerializer : OpenStringEnumSerializer<StringFormat>(
+    serialName = "com.agentclientprotocol.model.v2.StringFormat",
+    knownValues = listOf(
+        StringFormat.Email,
+        StringFormat.Uri,
+        StringFormat.Date,
+        StringFormat.DateTime,
+    ),
+    wireValue = StringFormat::value,
+    unknown = StringFormat::Unknown,
+)
+
+/**
+ * Items for a multi-select (array) property schema.
+ *
+ * This is a hybrid union: [StringItems] is tagged (`{"type":"string","enum":[…]}`),
+ * [Titled] is untagged and detected by its `anyOf` field, and any other `type`
+ * discriminator deserializes to [Unknown] with the full raw JSON preserved.
+ */
+@UnstableApi
+@Serializable(with = MultiSelectItemsSerializer::class)
+public sealed class MultiSelectItems {
+    /**
+     * Multi-select string items with plain string values.
+     */
+    @Serializable
+    public data class StringItems(
+        @SerialName("enum") val values: List<String>,
+    ) : MultiSelectItems()
+
+    /**
+     * Titled multi-select items with human-readable labels.
+     */
+    @Serializable
+    public data class Titled(
+        @SerialName("anyOf") val options: List<EnumOption>,
+    ) : MultiSelectItems()
+
+    /**
+     * Custom or future typed multi-select items.
+     *
+     * Type values beginning with `_` are reserved for implementation-specific
+     * extensions. Unknown values that do not begin with `_` are reserved for future ACP
+     * variants and MUST NOT be treated as custom extensions.
+     *
+     * [rawJson] holds the complete payload as received (including the discriminator), so
+     * re-serializing emits it byte-identically.
+     */
+    public data class Unknown(val type: String, val rawJson: JsonObject) : MultiSelectItems()
+}
+
+@OptIn(UnstableApi::class)
+internal object MultiSelectItemsSerializer : KSerializer<MultiSelectItems> {
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("com.agentclientprotocol.model.v2.MultiSelectItems")
+
+    override fun serialize(encoder: Encoder, value: MultiSelectItems) {
+        val jsonEncoder = encoder as JsonEncoder
+        val jsonObject = when (value) {
+            is MultiSelectItems.StringItems -> {
+                val payload = jsonEncoder.json
+                    .encodeToJsonElement(MultiSelectItems.StringItems.serializer(), value).jsonObject
+                JsonObject(mapOf("type" to JsonPrimitive("string")) + payload)
+            }
+
+            is MultiSelectItems.Titled ->
+                jsonEncoder.json.encodeToJsonElement(MultiSelectItems.Titled.serializer(), value).jsonObject
+
+            is MultiSelectItems.Unknown -> value.rawJson
+        }
+        jsonEncoder.encodeJsonElement(jsonObject)
+    }
+
+    override fun deserialize(decoder: Decoder): MultiSelectItems {
+        val jsonDecoder = decoder as JsonDecoder
+        val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
+        val type = (jsonObject["type"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+        return when {
+            type == "string" ->
+                jsonDecoder.json.decodeFromJsonElement(MultiSelectItems.StringItems.serializer(), jsonObject)
+
+            type != null -> MultiSelectItems.Unknown(type, jsonObject)
+            "anyOf" in jsonObject ->
+                jsonDecoder.json.decodeFromJsonElement(MultiSelectItems.Titled.serializer(), jsonObject)
+
+            else -> throw SerializationException(
+                "Cannot determine MultiSelectItems shape; expected a 'type' or 'anyOf' field"
+            )
+        }
+    }
+}
+
+/**
+ * Property schema for elicitation form fields.
+ *
+ * Each known variant corresponds to a JSON Schema `type` value.
+ *
+ * This is an open tagged union: an unrecognized `type` discriminator deserializes to
+ * [Unknown] with the full raw JSON preserved, so newer ACP variants and `_`-prefixed
+ * extensions degrade gracefully. Clients that do not understand a property schema type
+ * MUST NOT render it as a known input control.
+ */
+@UnstableApi
+@Serializable(with = ElicitationPropertySchemaSerializer::class)
+public sealed class ElicitationPropertySchema {
+    /**
+     * String property (or single-select enum when `enum`/`oneOf` is set).
+     */
+    @Serializable
+    public data class StringProperty(
+        val title: String? = null,
+        val description: String? = null,
+        val minLength: Int? = null,
+        val maxLength: Int? = null,
+        val pattern: String? = null,
+        val format: StringFormat? = null,
+        val default: String? = null,
+        @SerialName("enum") val enumValues: List<String>? = null,
+        @SerialName("oneOf") val oneOf: List<EnumOption>? = null,
+    ) : ElicitationPropertySchema()
+
+    /**
+     * Number (floating-point) property.
+     */
+    @Serializable
+    public data class NumberProperty(
+        val title: String? = null,
+        val description: String? = null,
+        val minimum: Double? = null,
+        val maximum: Double? = null,
+        val default: Double? = null,
+    ) : ElicitationPropertySchema()
+
+    /**
+     * Integer property.
+     */
+    @Serializable
+    public data class IntegerProperty(
+        val title: String? = null,
+        val description: String? = null,
+        val minimum: Long? = null,
+        val maximum: Long? = null,
+        val default: Long? = null,
+    ) : ElicitationPropertySchema()
+
+    /**
+     * Boolean property.
+     */
+    @Serializable
+    public data class BooleanProperty(
+        val title: String? = null,
+        val description: String? = null,
+        val default: Boolean? = null,
+    ) : ElicitationPropertySchema()
+
+    /**
+     * Multi-select array property.
+     */
+    @Serializable
+    public data class ArrayProperty(
+        val title: String? = null,
+        val description: String? = null,
+        val minItems: Long? = null,
+        val maxItems: Long? = null,
+        val items: MultiSelectItems,
+        val default: List<String>? = null,
+    ) : ElicitationPropertySchema()
+
+    /**
+     * Custom or future elicitation property schema.
+     *
+     * Discriminator values beginning with `_` are reserved for implementation-specific
+     * extensions. Unknown values that do not begin with `_` are reserved for future ACP
+     * variants and MUST NOT be treated as custom extensions.
+     *
+     * [rawJson] holds the complete payload as received (including the discriminator), so
+     * re-serializing emits it byte-identically.
+     */
+    public data class Unknown(val type: String, val rawJson: JsonObject) : ElicitationPropertySchema()
+}
+
+@OptIn(UnstableApi::class)
+internal object ElicitationPropertySchemaSerializer : OpenTaggedUnionSerializer<ElicitationPropertySchema>(
+    serialName = "com.agentclientprotocol.model.v2.ElicitationPropertySchema",
+    discriminatorKey = "type",
+    known = mapOf(
+        "string" to ElicitationPropertySchema.StringProperty.serializer(),
+        "number" to ElicitationPropertySchema.NumberProperty.serializer(),
+        "integer" to ElicitationPropertySchema.IntegerProperty.serializer(),
+        "boolean" to ElicitationPropertySchema.BooleanProperty.serializer(),
+        "array" to ElicitationPropertySchema.ArrayProperty.serializer(),
+    ),
+    discriminator = { value ->
+        when (value) {
+            is ElicitationPropertySchema.StringProperty -> "string"
+            is ElicitationPropertySchema.NumberProperty -> "number"
+            is ElicitationPropertySchema.IntegerProperty -> "integer"
+            is ElicitationPropertySchema.BooleanProperty -> "boolean"
+            is ElicitationPropertySchema.ArrayProperty -> "array"
+            is ElicitationPropertySchema.Unknown -> value.type
+        }
+    },
+    unknown = ElicitationPropertySchema::Unknown,
+    rawJson = { (it as? ElicitationPropertySchema.Unknown)?.rawJson },
+)
+
+/**
+ * Type-safe elicitation schema for requesting structured user input.
+ */
+@UnstableApi
+@Serializable
+public data class ElicitationSchema(
+    @SerialName("type") @EncodeDefault val type: ElicitationSchemaType = ElicitationSchemaType.OBJECT,
+    val title: String? = null,
+    val properties: Map<String, ElicitationPropertySchema> = emptyMap(),
+    val required: List<String>? = null,
+    val description: String? = null,
+)
+
+/**
+ * The user's action in response to an elicitation.
+ *
+ * This is an open tagged union: an unrecognized `action` discriminator deserializes to
+ * [Unknown] with the full raw JSON preserved, so newer ACP variants and `_`-prefixed
+ * extensions degrade gracefully. Agents that do not understand an action MUST NOT treat
+ * it as a known elicitation action — in particular, not as acceptance.
+ */
+@UnstableApi
+@Serializable(with = ElicitationActionSerializer::class)
+public sealed class ElicitationAction {
+    /**
+     * The user accepted and provided content.
+     */
+    @Serializable
+    public data class Accept(
+        val content: Map<String, ElicitationContentValue>? = null,
+    ) : ElicitationAction()
+
+    /**
+     * The user declined the elicitation.
+     */
+    @Serializable
+    public data object Decline : ElicitationAction()
+
+    /**
+     * The elicitation was cancelled.
+     */
+    @Serializable
+    public data object Cancel : ElicitationAction()
+
+    /**
+     * Custom or future elicitation action.
+     *
+     * Discriminator values beginning with `_` are reserved for implementation-specific
+     * extensions. Unknown values that do not begin with `_` are reserved for future ACP
+     * variants and MUST NOT be treated as custom extensions.
+     *
+     * [rawJson] holds the complete payload as received (including the discriminator), so
+     * re-serializing emits it byte-identically. Agents SHOULD preserve it when storing,
+     * replaying, proxying, or forwarding elicitation responses.
+     */
+    public data class Unknown(val action: String, val rawJson: JsonObject) : ElicitationAction()
+}
+
+@OptIn(UnstableApi::class)
+internal object ElicitationActionSerializer : OpenTaggedUnionSerializer<ElicitationAction>(
+    serialName = "com.agentclientprotocol.model.v2.ElicitationAction",
+    discriminatorKey = "action",
+    known = mapOf(
+        "accept" to ElicitationAction.Accept.serializer(),
+        "decline" to ElicitationAction.Decline.serializer(),
+        "cancel" to ElicitationAction.Cancel.serializer(),
+    ),
+    discriminator = { value ->
+        when (value) {
+            is ElicitationAction.Accept -> "accept"
+            is ElicitationAction.Decline -> "decline"
+            is ElicitationAction.Cancel -> "cancel"
+            is ElicitationAction.Unknown -> value.action
+        }
+    },
+    unknown = ElicitationAction::Unknown,
+    rawJson = { (it as? ElicitationAction.Unknown)?.rawJson },
+)
+
+/**
+ * The mode of elicitation, determining how user input is collected.
+ *
+ * Unlike the v1 Kotlin model, every mode carries its [scope] (flattened on the wire
+ * beside `mode`), mirroring the Rust v2 schema — in v1 Kotlin the scope lives on the
+ * enclosing request instead.
+ *
+ * This is an open tagged union: an unrecognized `mode` discriminator deserializes to
+ * [Unknown] with the full raw JSON preserved, so newer ACP variants and `_`-prefixed
+ * extensions degrade gracefully. Clients MUST NOT render an unknown mode as a known
+ * elicitation mode.
+ *
+ * No v1 conversions are provided for this union: the v1 Kotlin mode type does not carry
+ * the scope, so neither direction has a faithful counterpart at this level. Conversion
+ * belongs at the request level once the v2 request types exist.
+ */
+@UnstableApi
+@Serializable(with = ElicitationModeSerializer::class)
+public sealed class ElicitationMode {
+    /**
+     * The scope this elicitation is tied to, flattened on the wire.
+     *
+     * Required for every mode — including [Unknown] ones.
+     */
+    public abstract val scope: ElicitationScope
+
+    /**
+     * Form-based elicitation where the client renders a form from the provided schema.
+     */
+    public data class Form(
+        override val scope: ElicitationScope,
+        val requestedSchema: ElicitationSchema,
+    ) : ElicitationMode()
+
+    /**
+     * URL-based elicitation where the client directs the user to a URL.
+     */
+    public data class Url(
+        override val scope: ElicitationScope,
+        val elicitationId: ElicitationId,
+        val url: String,
+    ) : ElicitationMode()
+
+    /**
+     * Custom or future elicitation mode.
+     *
+     * Discriminator values beginning with `_` are reserved for implementation-specific
+     * extensions. Unknown values that do not begin with `_` are reserved for future ACP
+     * variants and MUST NOT be treated as custom extensions.
+     *
+     * Even unknown modes must carry a resolvable scope — decoding fails otherwise.
+     * [rawJson] holds the complete payload as received (including the discriminator), so
+     * re-serializing emits it byte-identically. Clients SHOULD preserve it when storing,
+     * replaying, proxying, or forwarding elicitation requests.
+     */
+    public data class Unknown(
+        val mode: String,
+        override val scope: ElicitationScope,
+        val rawJson: JsonObject,
+    ) : ElicitationMode()
+}
+
+@OptIn(UnstableApi::class)
+internal object ElicitationModeSerializer : KSerializer<ElicitationMode> {
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("com.agentclientprotocol.model.v2.ElicitationMode")
+
+    override fun serialize(encoder: Encoder, value: ElicitationMode) {
+        val jsonEncoder = encoder as JsonEncoder
+        val jsonObject = when (value) {
+            is ElicitationMode.Unknown -> value.rawJson
+            else -> buildJsonObject {
+                put(
+                    "mode",
+                    JsonPrimitive(
+                        when (value) {
+                            is ElicitationMode.Form -> "form"
+                            is ElicitationMode.Url -> "url"
+                            is ElicitationMode.Unknown -> error("unreachable")
+                        },
+                    ),
+                )
+                jsonEncoder.json.encodeToJsonElement(ElicitationScope.serializer(), value.scope)
+                    .jsonObject.forEach { (key, element) -> put(key, element) }
+                when (value) {
+                    is ElicitationMode.Form -> put(
+                        "requestedSchema",
+                        jsonEncoder.json.encodeToJsonElement(ElicitationSchema.serializer(), value.requestedSchema),
+                    )
+                    is ElicitationMode.Url -> {
+                        put("elicitationId", JsonPrimitive(value.elicitationId.value))
+                        put("url", JsonPrimitive(value.url))
+                    }
+                    is ElicitationMode.Unknown -> error("unreachable")
+                }
+            }
+        }
+        jsonEncoder.encodeJsonElement(jsonObject)
+    }
+
+    override fun deserialize(decoder: Decoder): ElicitationMode {
+        val jsonDecoder = decoder as JsonDecoder
+        val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
+        val mode = (jsonObject["mode"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+            ?: throw SerializationException("Missing 'mode' discriminator in ElicitationMode")
+        // The scope fields sit beside `mode` in the same object; the scope serializer
+        // picks out sessionId/toolCallId or requestId and rejects ambiguous payloads.
+        val scope = jsonDecoder.json.decodeFromJsonElement(ElicitationScope.serializer(), jsonObject)
+        return when (mode) {
+            "form" -> ElicitationMode.Form(
+                scope = scope,
+                requestedSchema = jsonDecoder.json.decodeFromJsonElement(
+                    ElicitationSchema.serializer(),
+                    jsonObject["requestedSchema"]
+                        ?: throw SerializationException("Missing 'requestedSchema' in 'form' ElicitationMode"),
+                ),
+            )
+            "url" -> ElicitationMode.Url(
+                scope = scope,
+                elicitationId = ElicitationId(
+                    (jsonObject["elicitationId"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+                        ?: throw SerializationException("Missing 'elicitationId' in 'url' ElicitationMode"),
+                ),
+                url = (jsonObject["url"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+                    ?: throw SerializationException("Missing 'url' in 'url' ElicitationMode"),
+            )
+            else -> ElicitationMode.Unknown(mode = mode, scope = scope, rawJson = jsonObject)
+        }
+    }
+}

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/MaybeUndefined.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/MaybeUndefined.kt
@@ -1,0 +1,157 @@
+@file:Suppress("unused")
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonObjectBuilder
+
+/**
+ * A three-state field for upsert payloads: absent, JSON `null`, or a value.
+ *
+ * v2 upsert payloads (e.g. `ToolCallUpdate`, the message upserts) give optional fields
+ * patch semantics: an omitted field leaves the existing value unchanged, `null` explicitly
+ * clears it, and a concrete value replaces it. Kotlin's `T?` collapses the first two states,
+ * so such fields are modeled with this type instead.
+ *
+ * This type intentionally has no [kotlinx.serialization.KSerializer]: whether a key is
+ * present on the wire is decided by the containing object, not the field value, and
+ * `ACPJson`'s `explicitNulls = false` would strip an explicit `JsonNull` emitted by a field
+ * serializer. Structs with [MaybeUndefined] fields use hand-written serializers that decode
+ * by key presence (absent → [Undefined], `null` → [Null]) and encode by skipping [Undefined]
+ * and emitting `JsonNull` for [Null].
+ */
+@UnstableApi
+public sealed class MaybeUndefined<out T> {
+    /**
+     * The field is not present; an existing value is left unchanged.
+     */
+    public data object Undefined : MaybeUndefined<Nothing>()
+
+    /**
+     * The field is present with a JSON `null` value; an existing value is cleared.
+     */
+    public data object Null : MaybeUndefined<Nothing>()
+
+    /**
+     * The field is present with a non-null value; it replaces an existing value.
+     */
+    public data class Value<out T>(public val value: T) : MaybeUndefined<T>()
+
+    /**
+     * The contained value, or `null` if the field is [Undefined] or [Null].
+     */
+    public fun valueOrNull(): T? = when (this) {
+        is Value -> value
+        Undefined, Null -> null
+    }
+
+    /**
+     * Transforms the contained value; [Undefined] and [Null] pass through unchanged.
+     */
+    public inline fun <R> map(transform: (T) -> R): MaybeUndefined<R> = when (this) {
+        is Value -> Value(transform(value))
+        Undefined -> Undefined
+        Null -> Null
+    }
+}
+
+/**
+ * Applies this field's patch semantics to a previous value: [MaybeUndefined.Undefined]
+ * keeps [previous], [MaybeUndefined.Null] clears it, and [MaybeUndefined.Value] replaces it.
+ */
+@UnstableApi
+public fun <T> MaybeUndefined<T>.update(previous: T?): T? = when (this) {
+    is MaybeUndefined.Value -> value
+    MaybeUndefined.Undefined -> previous
+    MaybeUndefined.Null -> null
+}
+
+/**
+ * This patch state unless it is [MaybeUndefined.Undefined], in which case [previous] is kept.
+ *
+ * Unlike [update], an explicit clear stays [MaybeUndefined.Null] so callers can decide how to
+ * render an explicitly cleared value (mirrors Rust's `apply_update` field handling).
+ */
+@UnstableApi
+internal fun <T> MaybeUndefined<T>.orPrevious(previous: MaybeUndefined<T>): MaybeUndefined<T> =
+    if (this is MaybeUndefined.Undefined) previous else this
+
+// Shared building blocks for the hand-written serializers of structs with [MaybeUndefined]
+// fields. Field semantics mirror the Rust schema's serde attributes:
+// `#[serde(default, skip_serializing_if = "MaybeUndefined::is_undefined")]` plus
+// `DefaultOnError` (and `VecSkipError` for collections).
+
+/**
+ * Decodes a tri-state field: absent key → [MaybeUndefined.Undefined], JSON `null` →
+ * [MaybeUndefined.Null], otherwise the decoded value.
+ *
+ * A present-but-malformed value degrades to [MaybeUndefined.Undefined] instead of failing,
+ * mirroring Rust's `DefaultOnError` on every `MaybeUndefined` field of the v2 schema.
+ */
+@OptIn(UnstableApi::class)
+internal fun <T> JsonObject.decodeMaybeUndefined(
+    json: Json,
+    key: String,
+    deserializer: DeserializationStrategy<T>,
+): MaybeUndefined<T> {
+    val element = this[key] ?: return MaybeUndefined.Undefined
+    if (element is JsonNull) return MaybeUndefined.Null
+    return try {
+        MaybeUndefined.Value(json.decodeFromJsonElement(deserializer, element))
+    } catch (_: Exception) {
+        // DefaultOnError parity: kotlinx tree decoding reports malformed shapes through a
+        // variety of RuntimeExceptions, not just SerializationException.
+        MaybeUndefined.Undefined
+    }
+}
+
+/**
+ * Decodes a tri-state collection field like [decodeMaybeUndefined], with Rust's `VecSkipError`
+ * semantics on top: items that fail to decode are skipped instead of failing the field, and a
+ * present-but-non-array value degrades to [MaybeUndefined.Undefined].
+ */
+@OptIn(UnstableApi::class)
+internal fun <T> JsonObject.decodeMaybeUndefinedList(
+    json: Json,
+    key: String,
+    itemDeserializer: DeserializationStrategy<T>,
+): MaybeUndefined<List<T>> {
+    val element = this[key] ?: return MaybeUndefined.Undefined
+    if (element is JsonNull) return MaybeUndefined.Null
+    val array = element as? JsonArray ?: return MaybeUndefined.Undefined
+    return MaybeUndefined.Value(
+        array.mapNotNull { item ->
+            try {
+                json.decodeFromJsonElement(itemDeserializer, item)
+            } catch (_: Exception) {
+                // VecSkipError parity; see decodeMaybeUndefined for why the catch is broad.
+                null
+            }
+        }
+    )
+}
+
+/**
+ * Encodes a tri-state field: [MaybeUndefined.Undefined] emits nothing, [MaybeUndefined.Null]
+ * emits an explicit JSON `null` (building the [JsonObject] directly bypasses `ACPJson`'s
+ * `explicitNulls = false`), and [MaybeUndefined.Value] emits the encoded value.
+ */
+@OptIn(UnstableApi::class)
+internal fun <T> JsonObjectBuilder.putMaybeUndefined(
+    json: Json,
+    key: String,
+    value: MaybeUndefined<T>,
+    serializer: SerializationStrategy<T>,
+) {
+    when (value) {
+        MaybeUndefined.Undefined -> {}
+        MaybeUndefined.Null -> put(key, JsonNull)
+        is MaybeUndefined.Value -> put(key, json.encodeToJsonElement(serializer, value.value))
+    }
+}

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/Nes.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/Nes.kt
@@ -1,0 +1,370 @@
+@file:Suppress("unused")
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.NesPosition
+import com.agentclientprotocol.model.NesTextEdit
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * What triggered the suggestion request.
+ *
+ * This is an open enum: unrecognized wire values deserialize to [Unknown] instead of
+ * failing, so newer ACP variants and `_`-prefixed extensions degrade gracefully.
+ */
+@UnstableApi
+@Serializable(with = NesTriggerKindSerializer::class)
+public sealed class NesTriggerKind {
+    /**
+     * The wire-format string for this trigger kind.
+     */
+    public abstract val value: String
+
+    /**
+     * Triggered by user typing or cursor movement.
+     */
+    public data object Automatic : NesTriggerKind() {
+        override val value: String = "automatic"
+    }
+
+    /**
+     * Triggered by a diagnostic appearing at or near the cursor.
+     */
+    public data object Diagnostic : NesTriggerKind() {
+        override val value: String = "diagnostic"
+    }
+
+    /**
+     * Triggered by an explicit user action (keyboard shortcut).
+     */
+    public data object Manual : NesTriggerKind() {
+        override val value: String = "manual"
+    }
+
+    /**
+     * Custom or future suggestion trigger kind.
+     *
+     * Values beginning with `_` are reserved for implementation-specific extensions.
+     * Unknown values that do not begin with `_` are reserved for future ACP variants
+     * and MUST NOT be treated as custom extensions.
+     *
+     * Receivers that cannot act on an unknown trigger kind SHOULD preserve it when storing,
+     * replaying, proxying, or forwarding protocol data, and otherwise degrade gracefully
+     * according to the field's semantics.
+     */
+    public data class Unknown(override val value: String) : NesTriggerKind()
+
+    public companion object {
+        /**
+         * Creates an implementation-specific extension trigger kind.
+         *
+         * Extension values must begin with `_` — all other values are reserved for ACP,
+         * including future ACP variants.
+         *
+         * @throws IllegalArgumentException if [value] does not begin with `_`
+         */
+        public fun extension(value: String): Unknown {
+            require(value.startsWith('_')) {
+                "Extension values must begin with '_'; values without the prefix are reserved for ACP (got '$value')"
+            }
+            return Unknown(value)
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object NesTriggerKindSerializer : OpenStringEnumSerializer<NesTriggerKind>(
+    serialName = "com.agentclientprotocol.model.v2.NesTriggerKind",
+    knownValues = listOf(
+        NesTriggerKind.Automatic,
+        NesTriggerKind.Diagnostic,
+        NesTriggerKind.Manual,
+    ),
+    wireValue = NesTriggerKind::value,
+    unknown = NesTriggerKind::Unknown,
+)
+
+/**
+ * The reason a suggestion was rejected.
+ *
+ * This is an open enum: unrecognized wire values deserialize to [Unknown] instead of
+ * failing, so newer ACP variants and `_`-prefixed extensions degrade gracefully.
+ */
+@UnstableApi
+@Serializable(with = NesRejectReasonSerializer::class)
+public sealed class NesRejectReason {
+    /**
+     * The wire-format string for this reject reason.
+     */
+    public abstract val value: String
+
+    /**
+     * The user explicitly dismissed the suggestion.
+     */
+    public data object Rejected : NesRejectReason() {
+        override val value: String = "rejected"
+    }
+
+    /**
+     * The suggestion was shown but the user continued editing without interacting.
+     */
+    public data object Ignored : NesRejectReason() {
+        override val value: String = "ignored"
+    }
+
+    /**
+     * The suggestion was superseded by a newer suggestion.
+     */
+    public data object Replaced : NesRejectReason() {
+        override val value: String = "replaced"
+    }
+
+    /**
+     * The request was cancelled before the agent returned a response.
+     */
+    public data object Cancelled : NesRejectReason() {
+        override val value: String = "cancelled"
+    }
+
+    /**
+     * Custom or future rejection reason.
+     *
+     * Values beginning with `_` are reserved for implementation-specific extensions.
+     * Unknown values that do not begin with `_` are reserved for future ACP variants
+     * and MUST NOT be treated as custom extensions.
+     *
+     * Receivers that cannot act on an unknown reject reason SHOULD preserve it when storing,
+     * replaying, proxying, or forwarding protocol data, and otherwise degrade gracefully
+     * according to the field's semantics.
+     */
+    public data class Unknown(override val value: String) : NesRejectReason()
+
+    public companion object {
+        /**
+         * Creates an implementation-specific extension reject reason.
+         *
+         * Extension values must begin with `_` — all other values are reserved for ACP,
+         * including future ACP variants.
+         *
+         * @throws IllegalArgumentException if [value] does not begin with `_`
+         */
+        public fun extension(value: String): Unknown {
+            require(value.startsWith('_')) {
+                "Extension values must begin with '_'; values without the prefix are reserved for ACP (got '$value')"
+            }
+            return Unknown(value)
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object NesRejectReasonSerializer : OpenStringEnumSerializer<NesRejectReason>(
+    serialName = "com.agentclientprotocol.model.v2.NesRejectReason",
+    knownValues = listOf(
+        NesRejectReason.Rejected,
+        NesRejectReason.Ignored,
+        NesRejectReason.Replaced,
+        NesRejectReason.Cancelled,
+    ),
+    wireValue = NesRejectReason::value,
+    unknown = NesRejectReason::Unknown,
+)
+
+/**
+ * Severity of a diagnostic.
+ *
+ * This is an open enum: unrecognized wire values deserialize to [Unknown] instead of
+ * failing, so newer ACP variants and `_`-prefixed extensions degrade gracefully.
+ */
+@UnstableApi
+@Serializable(with = NesDiagnosticSeveritySerializer::class)
+public sealed class NesDiagnosticSeverity {
+    /**
+     * The wire-format string for this severity.
+     */
+    public abstract val value: String
+
+    /**
+     * An error.
+     */
+    public data object Error : NesDiagnosticSeverity() {
+        override val value: String = "error"
+    }
+
+    /**
+     * A warning.
+     */
+    public data object Warning : NesDiagnosticSeverity() {
+        override val value: String = "warning"
+    }
+
+    /**
+     * An informational message.
+     */
+    public data object Information : NesDiagnosticSeverity() {
+        override val value: String = "information"
+    }
+
+    /**
+     * A hint.
+     */
+    public data object Hint : NesDiagnosticSeverity() {
+        override val value: String = "hint"
+    }
+
+    /**
+     * Custom or future diagnostic severity.
+     *
+     * Values beginning with `_` are reserved for implementation-specific extensions.
+     * Unknown values that do not begin with `_` are reserved for future ACP variants
+     * and MUST NOT be treated as custom extensions.
+     *
+     * Receivers that cannot act on an unknown severity SHOULD preserve it when storing,
+     * replaying, proxying, or forwarding protocol data, and otherwise degrade gracefully
+     * according to the field's semantics.
+     */
+    public data class Unknown(override val value: String) : NesDiagnosticSeverity()
+
+    public companion object {
+        /**
+         * Creates an implementation-specific extension severity.
+         *
+         * Extension values must begin with `_` — all other values are reserved for ACP,
+         * including future ACP variants.
+         *
+         * @throws IllegalArgumentException if [value] does not begin with `_`
+         */
+        public fun extension(value: String): Unknown {
+            require(value.startsWith('_')) {
+                "Extension values must begin with '_'; values without the prefix are reserved for ACP (got '$value')"
+            }
+            return Unknown(value)
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object NesDiagnosticSeveritySerializer : OpenStringEnumSerializer<NesDiagnosticSeverity>(
+    serialName = "com.agentclientprotocol.model.v2.NesDiagnosticSeverity",
+    knownValues = listOf(
+        NesDiagnosticSeverity.Error,
+        NesDiagnosticSeverity.Warning,
+        NesDiagnosticSeverity.Information,
+        NesDiagnosticSeverity.Hint,
+    ),
+    wireValue = NesDiagnosticSeverity::value,
+    unknown = NesDiagnosticSeverity::Unknown,
+)
+
+/**
+ * A suggestion produced by next-edit-suggestion (NES) processing.
+ *
+ * Unlike v1, every variant identifies itself with `suggestionId` on the wire
+ * (renamed from v1's `id`).
+ *
+ * This is an open tagged union: an unrecognized `kind` discriminator deserializes to
+ * [Unknown] with the full raw JSON preserved, so newer ACP variants and `_`-prefixed
+ * extensions degrade gracefully.
+ */
+@UnstableApi
+@Serializable(with = NesSuggestionSerializer::class)
+public sealed class NesSuggestion {
+    /**
+     * Unique identifier for accept/reject tracking.
+     */
+    public abstract val suggestionId: String
+
+    /**
+     * A text edit suggestion.
+     */
+    @Serializable
+    public data class Edit(
+        override val suggestionId: String,
+        val uri: String,
+        val edits: List<NesTextEdit>,
+        val cursorPosition: NesPosition? = null,
+    ) : NesSuggestion()
+
+    /**
+     * A jump-to-location suggestion.
+     */
+    @Serializable
+    public data class Jump(
+        override val suggestionId: String,
+        val uri: String,
+        val position: NesPosition,
+    ) : NesSuggestion()
+
+    /**
+     * A rename symbol suggestion.
+     */
+    @Serializable
+    public data class Rename(
+        override val suggestionId: String,
+        val uri: String,
+        val position: NesPosition,
+        val newName: String,
+    ) : NesSuggestion()
+
+    /**
+     * A search-and-replace suggestion.
+     */
+    @Serializable
+    public data class SearchAndReplace(
+        override val suggestionId: String,
+        val uri: String,
+        val search: String,
+        val replace: String,
+        val isRegex: Boolean? = null,
+    ) : NesSuggestion()
+
+    /**
+     * Custom or future NES suggestion.
+     *
+     * Discriminator values beginning with `_` are reserved for implementation-specific
+     * extensions. Unknown values that do not begin with `_` are reserved for future ACP
+     * variants and MUST NOT be treated as custom extensions.
+     *
+     * Even unknown suggestions must carry `suggestionId` — decoding fails otherwise.
+     * [rawJson] holds the complete payload as received (including the discriminator), so
+     * re-serializing emits it byte-identically. Receivers that do not understand this
+     * suggestion kind SHOULD preserve it when storing, replaying, proxying, or forwarding
+     * suggestions, and otherwise ignore it or display it generically.
+     */
+    public data class Unknown(
+        val kind: String,
+        override val suggestionId: String,
+        val rawJson: JsonObject,
+    ) : NesSuggestion()
+}
+
+@OptIn(UnstableApi::class)
+internal object NesSuggestionSerializer : OpenTaggedUnionSerializer<NesSuggestion>(
+    serialName = "com.agentclientprotocol.model.v2.NesSuggestion",
+    discriminatorKey = "kind",
+    known = mapOf(
+        "edit" to NesSuggestion.Edit.serializer(),
+        "jump" to NesSuggestion.Jump.serializer(),
+        "rename" to NesSuggestion.Rename.serializer(),
+        "searchAndReplace" to NesSuggestion.SearchAndReplace.serializer(),
+    ),
+    discriminator = { value ->
+        when (value) {
+            is NesSuggestion.Edit -> "edit"
+            is NesSuggestion.Jump -> "jump"
+            is NesSuggestion.Rename -> "rename"
+            is NesSuggestion.SearchAndReplace -> "searchAndReplace"
+            is NesSuggestion.Unknown -> value.kind
+        }
+    },
+    unknown = { kind, rawJson ->
+        val suggestionId = (rawJson["suggestionId"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+            ?: throw SerializationException("Missing 'suggestionId' in unknown NesSuggestion")
+        NesSuggestion.Unknown(kind = kind, suggestionId = suggestionId, rawJson = rawJson)
+    },
+    rawJson = { (it as? NesSuggestion.Unknown)?.rawJson },
+)

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/OpenStringEnumSerializer.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/OpenStringEnumSerializer.kt
@@ -1,0 +1,48 @@
+package com.agentclientprotocol.model.v2
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Base serializer for open string enums in the v2 protocol schema.
+ *
+ * Open enums list their known values explicitly and capture any unrecognized string in an
+ * `Unknown` fallback variant instead of failing deserialization. This keeps older
+ * implementations forward-compatible when newer ACP versions or extensions add variants:
+ *
+ * - Values beginning with `_` are reserved for implementation-specific extensions.
+ * - Values that do not begin with `_` are reserved for ACP, including future ACP variants.
+ * - Unknown values are preserved as-is so they survive storing, replaying, proxying,
+ *   and forwarding.
+ *
+ * See the v2 [Enum Variant Extension](https://agentclientprotocol.com/rfds/v2/enum-variant-extension) RFD.
+ *
+ * @param serialName fully-qualified serial name of the enum type
+ * @param knownValues all known values of the enum, excluding the `Unknown` fallback
+ * @param wireValue extracts the wire-format string of a value
+ * @param unknown creates the fallback variant carrying an unrecognized wire string
+ */
+internal abstract class OpenStringEnumSerializer<T : Any>(
+    serialName: String,
+    knownValues: List<T>,
+    private val wireValue: (T) -> String,
+    private val unknown: (String) -> T,
+) : KSerializer<T> {
+    private val known: Map<String, T> = knownValues.associateBy(wireValue)
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor(serialName, PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: T) {
+        encoder.encodeString(wireValue(value))
+    }
+
+    override fun deserialize(decoder: Decoder): T {
+        val raw = decoder.decodeString()
+        return known[raw] ?: unknown(raw)
+    }
+}

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/OpenTaggedUnionSerializer.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/OpenTaggedUnionSerializer.kt
@@ -1,0 +1,91 @@
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * Base serializer for open tagged unions in the v2 protocol schema.
+ *
+ * Open tagged unions are JSON objects discriminated by a string field (usually `type`).
+ * Known discriminators delegate to the matching variant serializer; an unrecognized
+ * discriminator deserializes to an `Unknown` fallback variant that preserves the **entire
+ * raw JSON object**, so it re-serializes byte-identically and survives storing, replaying,
+ * proxying, and forwarding:
+ *
+ * - Discriminator values beginning with `_` are reserved for implementation-specific
+ *   extensions. Values that do not begin with `_` are reserved for ACP, including future
+ *   ACP variants.
+ * - A **known** discriminator whose payload fails its variant serializer still fails —
+ *   the fallback must not mask malformed data.
+ * - A missing or non-string discriminator fails instead of guessing a variant.
+ *
+ * See the v2 [Enum Variant Extension](https://agentclientprotocol.com/rfds/v2/enum-variant-extension) RFD.
+ *
+ * @param serialName fully-qualified serial name of the union type
+ * @param discriminatorKey name of the JSON field holding the variant discriminator
+ * @param known variant serializers by discriminator value, excluding the `Unknown` fallback
+ * @param discriminator extracts the wire discriminator value of a union value
+ * @param unknown creates the fallback variant from an unrecognized discriminator and the
+ *   full raw JSON object as received
+ * @param rawJson returns the preserved raw JSON of a fallback value, or `null` for known variants
+ */
+internal abstract class OpenTaggedUnionSerializer<T : Any>(
+    serialName: String,
+    private val discriminatorKey: String,
+    private val known: Map<String, KSerializer<out T>>,
+    private val discriminator: (T) -> String,
+    private val unknown: (type: String, rawJson: JsonObject) -> T,
+    private val rawJson: (T) -> JsonObject?,
+) : KSerializer<T> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor(serialName)
+
+    override fun serialize(encoder: Encoder, value: T) {
+        val jsonEncoder = encoder as JsonEncoder
+        val raw = rawJson(value)
+        val jsonObject = if (raw != null) {
+            raw
+        } else {
+            val type = discriminator(value)
+
+            @Suppress("UNCHECKED_CAST")
+            val serializer = known.getValue(type) as KSerializer<T>
+            val payload = jsonEncoder.json.encodeToJsonElement(serializer, value).jsonObject
+            buildJsonObject {
+                put(discriminatorKey, JsonPrimitive(type))
+                payload.forEach { (key, element) ->
+                    if (key != discriminatorKey) put(key, element)
+                }
+            }
+        }
+        jsonEncoder.encodeJsonElement(jsonObject)
+    }
+
+    override fun deserialize(decoder: Decoder): T {
+        val jsonDecoder = decoder as JsonDecoder
+        val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
+        val discriminatorElement = jsonObject[discriminatorKey]
+            ?: throw SerializationException(
+                "Missing '$discriminatorKey' discriminator in ${descriptor.serialName}"
+            )
+        val type = (discriminatorElement as? JsonPrimitive)?.takeIf { it.isString }?.content
+            ?: throw SerializationException(
+                "'$discriminatorKey' discriminator must be a string in ${descriptor.serialName}"
+            )
+        // Known discriminator: delegate — a malformed payload must fail, not fall back.
+        val serializer = known[type] ?: return unknown(type, jsonObject)
+        return jsonDecoder.json.decodeFromJsonElement(serializer, jsonObject)
+    }
+}

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/Plan.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/Plan.kt
@@ -1,0 +1,358 @@
+@file:Suppress("unused")
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.AcpWithMeta
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.jvm.JvmInline
+
+/**
+ * Priority levels for plan entries.
+ *
+ * Used to indicate the relative importance or urgency of different
+ * tasks in the execution plan.
+ *
+ * This is an open enum: unrecognized wire values deserialize to [Unknown] instead of
+ * failing, so newer ACP variants and `_`-prefixed extensions degrade gracefully.
+ *
+ * See protocol docs: [Plan Entries](https://agentclientprotocol.com/protocol/agent-plan#plan-entries)
+ */
+@UnstableApi
+@Serializable(with = PlanEntryPrioritySerializer::class)
+public sealed class PlanEntryPriority {
+    /**
+     * The wire-format string for this priority.
+     */
+    public abstract val value: String
+
+    /**
+     * High priority task - critical to the overall goal.
+     */
+    public data object High : PlanEntryPriority() {
+        override val value: String = "high"
+    }
+
+    /**
+     * Medium priority task - important but not critical.
+     */
+    public data object Medium : PlanEntryPriority() {
+        override val value: String = "medium"
+    }
+
+    /**
+     * Low priority task - nice to have but not essential.
+     */
+    public data object Low : PlanEntryPriority() {
+        override val value: String = "low"
+    }
+
+    /**
+     * Custom or future plan entry priority.
+     *
+     * Values beginning with `_` are reserved for implementation-specific extensions.
+     * Unknown values that do not begin with `_` are reserved for future ACP variants
+     * and MUST NOT be treated as custom extensions.
+     *
+     * Receivers that cannot act on an unknown priority SHOULD preserve it when storing,
+     * replaying, proxying, or forwarding protocol data, and otherwise degrade gracefully
+     * according to the field's semantics.
+     */
+    public data class Unknown(override val value: String) : PlanEntryPriority()
+
+    public companion object {
+        /**
+         * Creates an implementation-specific extension priority.
+         *
+         * Extension values must begin with `_` — all other values are reserved for ACP,
+         * including future ACP variants.
+         *
+         * @throws IllegalArgumentException if [value] does not begin with `_`
+         */
+        public fun extension(value: String): Unknown {
+            require(value.startsWith('_')) {
+                "Extension values must begin with '_'; values without the prefix are reserved for ACP (got '$value')"
+            }
+            return Unknown(value)
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object PlanEntryPrioritySerializer : OpenStringEnumSerializer<PlanEntryPriority>(
+    serialName = "com.agentclientprotocol.model.v2.PlanEntryPriority",
+    knownValues = listOf(
+        PlanEntryPriority.High,
+        PlanEntryPriority.Medium,
+        PlanEntryPriority.Low,
+    ),
+    wireValue = PlanEntryPriority::value,
+    unknown = PlanEntryPriority::Unknown,
+)
+
+/**
+ * Status of a plan entry in the execution flow.
+ *
+ * Tracks the lifecycle of each task from planning through completion.
+ *
+ * This is an open enum: unrecognized wire values deserialize to [Unknown] instead of
+ * failing, so newer ACP variants and `_`-prefixed extensions degrade gracefully.
+ *
+ * See protocol docs: [Plan Entries](https://agentclientprotocol.com/protocol/agent-plan#plan-entries)
+ */
+@UnstableApi
+@Serializable(with = PlanEntryStatusSerializer::class)
+public sealed class PlanEntryStatus {
+    /**
+     * The wire-format string for this status.
+     */
+    public abstract val value: String
+
+    /**
+     * The task has not started yet.
+     */
+    public data object Pending : PlanEntryStatus() {
+        override val value: String = "pending"
+    }
+
+    /**
+     * The task is currently being worked on.
+     */
+    public data object InProgress : PlanEntryStatus() {
+        override val value: String = "in_progress"
+    }
+
+    /**
+     * The task has been successfully completed.
+     */
+    public data object Completed : PlanEntryStatus() {
+        override val value: String = "completed"
+    }
+
+    /**
+     * Custom or future plan entry status.
+     *
+     * Values beginning with `_` are reserved for implementation-specific extensions.
+     * Unknown values that do not begin with `_` are reserved for future ACP variants
+     * and MUST NOT be treated as custom extensions.
+     *
+     * Receivers that cannot act on an unknown status SHOULD preserve it when storing,
+     * replaying, proxying, or forwarding protocol data, and otherwise degrade gracefully
+     * according to the field's semantics.
+     */
+    public data class Unknown(override val value: String) : PlanEntryStatus()
+
+    public companion object {
+        /**
+         * Creates an implementation-specific extension status.
+         *
+         * Extension values must begin with `_` — all other values are reserved for ACP,
+         * including future ACP variants.
+         *
+         * @throws IllegalArgumentException if [value] does not begin with `_`
+         */
+        public fun extension(value: String): Unknown {
+            require(value.startsWith('_')) {
+                "Extension values must begin with '_'; values without the prefix are reserved for ACP (got '$value')"
+            }
+            return Unknown(value)
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object PlanEntryStatusSerializer : OpenStringEnumSerializer<PlanEntryStatus>(
+    serialName = "com.agentclientprotocol.model.v2.PlanEntryStatus",
+    knownValues = listOf(
+        PlanEntryStatus.Pending,
+        PlanEntryStatus.InProgress,
+        PlanEntryStatus.Completed,
+    ),
+    wireValue = PlanEntryStatus::value,
+    unknown = PlanEntryStatus::Unknown,
+)
+
+/**
+ * Unique identifier for a plan within a session.
+ *
+ * New in v2: v1 sessions had a single implicit plan, so its updates carried no ID.
+ */
+@UnstableApi
+@JvmInline
+@Serializable
+public value class PlanId(public val value: String) {
+    override fun toString(): String = value
+}
+
+/**
+ * A single entry in the execution plan.
+ *
+ * Represents a task or goal that the agent intends to accomplish as part of fulfilling the
+ * user's request. Same shape as v1's entry, but [priority] and [status] reference the v2
+ * open enums.
+ *
+ * See protocol docs: [Plan Entries](https://agentclientprotocol.com/protocol/agent-plan#plan-entries)
+ */
+@UnstableApi
+@Serializable
+public data class PlanEntry(
+    /**
+     * Human-readable description of what this task aims to accomplish.
+     */
+    val content: String,
+    /**
+     * The relative importance of this task.
+     */
+    val priority: PlanEntryPriority,
+    /**
+     * Current execution status of this task.
+     */
+    val status: PlanEntryStatus,
+    override val _meta: JsonElement? = null,
+) : AcpWithMeta
+
+/**
+ * Updated content for a plan.
+ *
+ * This is an open tagged union discriminated by `type`: an unrecognized type deserializes
+ * to [Unknown] with the full raw JSON preserved. Every variant — including [Unknown] —
+ * identifies its plan through [planId].
+ */
+@UnstableApi
+@Serializable(with = PlanUpdateContentSerializer::class)
+public sealed class PlanUpdateContent {
+    /**
+     * The plan this content updates.
+     */
+    public abstract val planId: PlanId
+
+    /**
+     * A plan represented as structured entries.
+     *
+     * When updating an item-based plan, the agent sends the complete list of entries with
+     * their current status; the client replaces the plan with each update.
+     */
+    @Serializable
+    public data class Items(
+        override val planId: PlanId,
+        val entries: List<PlanEntry>,
+        override val _meta: JsonElement? = null,
+    ) : PlanUpdateContent(), AcpWithMeta
+
+    /**
+     * **UNSTABLE**
+     *
+     * This capability is not part of the spec yet, and may be removed or changed at any point.
+     *
+     * A URI pointing to a file containing the plan.
+     */
+    @Serializable
+    public data class File(
+        override val planId: PlanId,
+        /**
+         * The URI of the file containing the plan.
+         */
+        val uri: String,
+        override val _meta: JsonElement? = null,
+    ) : PlanUpdateContent(), AcpWithMeta
+
+    /**
+     * **UNSTABLE**
+     *
+     * This capability is not part of the spec yet, and may be removed or changed at any point.
+     *
+     * Raw markdown content for the plan.
+     */
+    @Serializable
+    public data class Markdown(
+        override val planId: PlanId,
+        /**
+         * Markdown content for the plan.
+         */
+        val content: String,
+        override val _meta: JsonElement? = null,
+    ) : PlanUpdateContent(), AcpWithMeta
+
+    /**
+     * Custom or future plan update content.
+     *
+     * Discriminator values beginning with `_` are reserved for implementation-specific
+     * extensions. Unknown values that do not begin with `_` are reserved for future ACP
+     * variants and MUST NOT be treated as custom extensions.
+     *
+     * Even unknown content must carry `planId` — decoding fails otherwise. [rawJson] holds
+     * the complete payload as received (including the discriminator), so re-serializing
+     * emits it byte-identically. Receivers that do not understand this content type SHOULD
+     * preserve it when storing, replaying, proxying, or forwarding plans, and otherwise
+     * ignore it or display it generically.
+     */
+    public data class Unknown(
+        val type: String,
+        override val planId: PlanId,
+        val rawJson: JsonObject,
+    ) : PlanUpdateContent()
+}
+
+@OptIn(UnstableApi::class)
+internal object PlanUpdateContentSerializer : OpenTaggedUnionSerializer<PlanUpdateContent>(
+    serialName = "com.agentclientprotocol.model.v2.PlanUpdateContent",
+    discriminatorKey = "type",
+    known = mapOf(
+        "items" to PlanUpdateContent.Items.serializer(),
+        "file" to PlanUpdateContent.File.serializer(),
+        "markdown" to PlanUpdateContent.Markdown.serializer(),
+    ),
+    discriminator = { value ->
+        when (value) {
+            is PlanUpdateContent.Items -> "items"
+            is PlanUpdateContent.File -> "file"
+            is PlanUpdateContent.Markdown -> "markdown"
+            is PlanUpdateContent.Unknown -> value.type
+        }
+    },
+    unknown = { type, rawJson ->
+        val planId = (rawJson["planId"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+            ?: throw SerializationException("Missing 'planId' in unknown PlanUpdateContent")
+        PlanUpdateContent.Unknown(type = type, planId = PlanId(planId), rawJson = rawJson)
+    },
+    rawJson = { (it as? PlanUpdateContent.Unknown)?.rawJson },
+)
+
+/**
+ * A content update for a plan identified by ID.
+ *
+ * v1's plan update carried the entries directly; v2 wraps them in [PlanUpdateContent] so a
+ * session can track several plans and describe them in more than one form.
+ *
+ * See protocol docs: [Agent Plan](https://agentclientprotocol.com/protocol/agent-plan)
+ */
+@UnstableApi
+@Serializable
+public data class PlanUpdate(
+    /**
+     * The updated plan content.
+     */
+    val plan: PlanUpdateContent,
+    override val _meta: JsonElement? = null,
+) : AcpWithMeta
+
+/**
+ * **UNSTABLE**
+ *
+ * This capability is not part of the spec yet, and may be removed or changed at any point.
+ *
+ * Removal notice for a plan identified by ID.
+ */
+@UnstableApi
+@Serializable
+public data class PlanRemoved(
+    /**
+     * The plan ID to remove.
+     */
+    val planId: PlanId,
+    override val _meta: JsonElement? = null,
+) : AcpWithMeta

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/Requests.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/Requests.kt
@@ -1,0 +1,577 @@
+@file:Suppress("unused")
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.AcpWithMeta
+import com.agentclientprotocol.model.AuthEnvVar
+import com.agentclientprotocol.model.AuthMethodId
+import com.agentclientprotocol.model.EnvVariable
+import com.agentclientprotocol.model.HttpHeader
+import com.agentclientprotocol.model.PermissionOptionId
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Describes an available authentication method.
+ *
+ * The `type` field acts as the discriminator in the serialized JSON form. Unlike v1,
+ * every variant identifies itself with `methodId` on the wire (renamed from v1's `id`),
+ * and the discriminator is **required** — a method without it is rejected instead of
+ * assumed to be agent auth.
+ *
+ * This is an open tagged union: an unrecognized `type` discriminator deserializes to
+ * [Unknown] with the full raw JSON preserved, so newer ACP variants and `_`-prefixed
+ * extensions degrade gracefully.
+ */
+@UnstableApi
+@Serializable(with = AuthMethodSerializer::class)
+public sealed class AuthMethod {
+    /**
+     * Unique identifier for this authentication method.
+     */
+    public abstract val methodId: AuthMethodId
+
+    /**
+     * Human-readable name of the authentication method.
+     */
+    public abstract val name: String
+
+    /**
+     * Optional description providing more details about this authentication method.
+     */
+    public abstract val description: String?
+
+    /**
+     * Agent handles authentication itself.
+     */
+    @Serializable
+    public data class Agent(
+        override val methodId: AuthMethodId,
+        override val name: String,
+        override val description: String? = null,
+        override val _meta: JsonElement? = null,
+    ) : AuthMethod(), AcpWithMeta
+
+    /**
+     * **UNSTABLE**
+     *
+     * This capability is not part of the spec yet, and may be removed or changed at any point.
+     *
+     * User provides a key that the client passes to the agent as an environment variable.
+     */
+    @Serializable
+    public data class EnvVar(
+        override val methodId: AuthMethodId,
+        override val name: String,
+        override val description: String? = null,
+        val vars: List<AuthEnvVar>,
+        val link: String? = null,
+        override val _meta: JsonElement? = null,
+    ) : AuthMethod(), AcpWithMeta
+
+    /**
+     * **UNSTABLE**
+     *
+     * This capability is not part of the spec yet, and may be removed or changed at any point.
+     *
+     * Client runs an interactive terminal for the user to authenticate via a TUI.
+     */
+    @Serializable
+    public data class Terminal(
+        override val methodId: AuthMethodId,
+        override val name: String,
+        override val description: String? = null,
+        val args: List<String> = emptyList(),
+        val env: List<EnvVariable> = emptyList(),
+        override val _meta: JsonElement? = null,
+    ) : AuthMethod(), AcpWithMeta
+
+    /**
+     * Custom or future authentication method.
+     *
+     * Discriminator values beginning with `_` are reserved for implementation-specific
+     * extensions. Unknown values that do not begin with `_` are reserved for future ACP
+     * variants and MUST NOT be treated as custom extensions.
+     *
+     * Even unknown methods must carry `methodId` and `name` — decoding fails otherwise.
+     * [rawJson] holds the complete payload as received (including the discriminator), so
+     * re-serializing emits it byte-identically. Clients that do not understand this
+     * method type SHOULD preserve it when storing, replaying, proxying, or forwarding
+     * initialization data, and otherwise ignore the method or display it generically.
+     */
+    public data class Unknown(
+        val type: String,
+        override val methodId: AuthMethodId,
+        override val name: String,
+        override val description: String? = null,
+        val rawJson: JsonObject,
+    ) : AuthMethod()
+}
+
+@OptIn(UnstableApi::class)
+internal object AuthMethodSerializer : OpenTaggedUnionSerializer<AuthMethod>(
+    serialName = "com.agentclientprotocol.model.v2.AuthMethod",
+    discriminatorKey = "type",
+    known = mapOf(
+        "agent" to AuthMethod.Agent.serializer(),
+        "env_var" to AuthMethod.EnvVar.serializer(),
+        "terminal" to AuthMethod.Terminal.serializer(),
+    ),
+    discriminator = { value ->
+        when (value) {
+            is AuthMethod.Agent -> "agent"
+            is AuthMethod.EnvVar -> "env_var"
+            is AuthMethod.Terminal -> "terminal"
+            is AuthMethod.Unknown -> value.type
+        }
+    },
+    unknown = { type, rawJson ->
+        val methodId = (rawJson["methodId"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+            ?: throw SerializationException("Missing 'methodId' in unknown AuthMethod")
+        val name = (rawJson["name"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+            ?: throw SerializationException("Missing 'name' in unknown AuthMethod")
+        AuthMethod.Unknown(
+            type = type,
+            methodId = AuthMethodId(methodId),
+            name = name,
+            description = (rawJson["description"] as? JsonPrimitive)?.takeIf { it.isString }?.content,
+            rawJson = rawJson,
+        )
+    },
+    rawJson = { (it as? AuthMethod.Unknown)?.rawJson },
+)
+
+/**
+ * Configuration for connecting to an MCP (Model Context Protocol) server.
+ *
+ * MCP servers provide tools and context that the agent can use when
+ * processing prompts.
+ *
+ * This is an open tagged union: an unrecognized `type` discriminator deserializes to
+ * [Unknown] with the full raw JSON preserved, so newer ACP variants and `_`-prefixed
+ * extensions degrade gracefully. Unlike v1, the `type` discriminator is **required** —
+ * a configuration without it is rejected instead of silently assumed to be stdio.
+ *
+ * See protocol docs: [MCP Servers](https://agentclientprotocol.com/protocol/session-setup#mcp-servers)
+ */
+@UnstableApi
+@Serializable(with = McpServerSerializer::class)
+public sealed class McpServer {
+    /**
+     * HTTP transport configuration
+     *
+     * Only available when the Agent capabilities include `session.mcp.http`.
+     */
+    @Serializable
+    public data class Http(
+        val name: String,
+        val url: String,
+        val headers: List<HttpHeader> = emptyList(),
+        override val _meta: JsonElement? = null,
+    ) : McpServer(), AcpWithMeta
+
+    /**
+     * Stdio transport configuration
+     *
+     * Only available when the Agent capabilities include `session.mcp.stdio`.
+     */
+    @Serializable
+    public data class Stdio(
+        val name: String,
+        val command: String,
+        val args: List<String> = emptyList(),
+        val env: List<EnvVariable> = emptyList(),
+        override val _meta: JsonElement? = null,
+    ) : McpServer(), AcpWithMeta
+
+    /**
+     * Custom or future MCP server transport configuration.
+     *
+     * Discriminator values beginning with `_` are reserved for implementation-specific
+     * extensions. Unknown values that do not begin with `_` are reserved for future ACP
+     * variants and MUST NOT be treated as custom extensions.
+     *
+     * [rawJson] holds the complete payload as received (including the discriminator), so
+     * re-serializing emits it byte-identically. Receivers that do not understand this
+     * transport SHOULD preserve it when storing, replaying, proxying, or forwarding
+     * session setup data, and otherwise ignore it or reject the server configuration.
+     */
+    public data class Unknown(val type: String, val rawJson: JsonObject) : McpServer()
+}
+
+@OptIn(UnstableApi::class)
+internal object McpServerSerializer : OpenTaggedUnionSerializer<McpServer>(
+    serialName = "com.agentclientprotocol.model.v2.McpServer",
+    discriminatorKey = "type",
+    known = mapOf(
+        "http" to McpServer.Http.serializer(),
+        "stdio" to McpServer.Stdio.serializer(),
+    ),
+    discriminator = { value ->
+        when (value) {
+            is McpServer.Http -> "http"
+            is McpServer.Stdio -> "stdio"
+            is McpServer.Unknown -> value.type
+        }
+    },
+    unknown = McpServer::Unknown,
+    rawJson = { (it as? McpServer.Unknown)?.rawJson },
+)
+
+/**
+ * Reasons why an agent stops active session work.
+ *
+ * This is an open enum: unrecognized wire values deserialize to [Unknown] instead of
+ * failing, so newer ACP variants and `_`-prefixed extensions degrade gracefully.
+ *
+ * See protocol docs: [Stop Reasons](https://agentclientprotocol.com/protocol/prompt-lifecycle#stop-reasons)
+ */
+@UnstableApi
+@Serializable(with = StopReasonSerializer::class)
+public sealed class StopReason {
+    /**
+     * The wire-format string for this stop reason.
+     */
+    public abstract val value: String
+
+    /**
+     * The active work ended successfully.
+     */
+    public data object EndTurn : StopReason() {
+        override val value: String = "end_turn"
+    }
+
+    /**
+     * The active work ended because the agent reached the maximum number of tokens.
+     */
+    public data object MaxTokens : StopReason() {
+        override val value: String = "max_tokens"
+    }
+
+    /**
+     * The active work ended because the agent reached the maximum number of
+     * allowed agent requests before returning idle.
+     */
+    public data object MaxTurnRequests : StopReason() {
+        override val value: String = "max_turn_requests"
+    }
+
+    /**
+     * The active work ended because the agent refused to continue. The user
+     * prompt and everything that comes after it won't be included in the next
+     * prompt, so this should be reflected in the UI.
+     */
+    public data object Refusal : StopReason() {
+        override val value: String = "refusal"
+    }
+
+    /**
+     * Active session work was cancelled by the client via `session/cancel`.
+     */
+    public data object Cancelled : StopReason() {
+        override val value: String = "cancelled"
+    }
+
+    /**
+     * Custom or future stop reason.
+     *
+     * Values beginning with `_` are reserved for implementation-specific extensions.
+     * Unknown values that do not begin with `_` are reserved for future ACP variants
+     * and MUST NOT be treated as custom extensions.
+     *
+     * Receivers that cannot act on an unknown stop reason SHOULD preserve it when storing,
+     * replaying, proxying, or forwarding protocol data, and otherwise degrade gracefully
+     * according to the field's semantics.
+     */
+    public data class Unknown(override val value: String) : StopReason()
+
+    public companion object {
+        /**
+         * Creates an implementation-specific extension stop reason.
+         *
+         * Extension values must begin with `_` — all other values are reserved for ACP,
+         * including future ACP variants.
+         *
+         * @throws IllegalArgumentException if [value] does not begin with `_`
+         */
+        public fun extension(value: String): Unknown {
+            require(value.startsWith('_')) {
+                "Extension values must begin with '_'; values without the prefix are reserved for ACP (got '$value')"
+            }
+            return Unknown(value)
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object StopReasonSerializer : OpenStringEnumSerializer<StopReason>(
+    serialName = "com.agentclientprotocol.model.v2.StopReason",
+    knownValues = listOf(
+        StopReason.EndTurn,
+        StopReason.MaxTokens,
+        StopReason.MaxTurnRequests,
+        StopReason.Refusal,
+        StopReason.Cancelled,
+    ),
+    wireValue = StopReason::value,
+    unknown = StopReason::Unknown,
+)
+
+/**
+ * The type of permission option being presented to the user.
+ *
+ * Helps clients choose appropriate icons and UI treatment.
+ *
+ * This is an open enum: unrecognized wire values deserialize to [Unknown] instead of
+ * failing, so newer ACP variants and `_`-prefixed extensions degrade gracefully.
+ */
+@UnstableApi
+@Serializable(with = PermissionOptionKindSerializer::class)
+public sealed class PermissionOptionKind {
+    /**
+     * The wire-format string for this kind.
+     */
+    public abstract val value: String
+
+    /**
+     * Allow this operation only this time.
+     */
+    public data object AllowOnce : PermissionOptionKind() {
+        override val value: String = "allow_once"
+    }
+
+    /**
+     * Allow this operation and remember the choice.
+     */
+    public data object AllowAlways : PermissionOptionKind() {
+        override val value: String = "allow_always"
+    }
+
+    /**
+     * Reject this operation only this time.
+     */
+    public data object RejectOnce : PermissionOptionKind() {
+        override val value: String = "reject_once"
+    }
+
+    /**
+     * Reject this operation and remember the choice.
+     */
+    public data object RejectAlways : PermissionOptionKind() {
+        override val value: String = "reject_always"
+    }
+
+    /**
+     * Custom or future permission option kind.
+     *
+     * Values beginning with `_` are reserved for implementation-specific extensions.
+     * Unknown values that do not begin with `_` are reserved for future ACP variants
+     * and MUST NOT be treated as custom extensions.
+     *
+     * Receivers that cannot act on an unknown kind SHOULD preserve it when storing,
+     * replaying, proxying, or forwarding protocol data, and otherwise degrade gracefully
+     * according to the field's semantics — in particular, an unknown kind MUST NOT be
+     * treated as any form of approval.
+     */
+    public data class Unknown(override val value: String) : PermissionOptionKind()
+
+    public companion object {
+        /**
+         * Creates an implementation-specific extension kind.
+         *
+         * Extension values must begin with `_` — all other values are reserved for ACP,
+         * including future ACP variants.
+         *
+         * @throws IllegalArgumentException if [value] does not begin with `_`
+         */
+        public fun extension(value: String): Unknown {
+            require(value.startsWith('_')) {
+                "Extension values must begin with '_'; values without the prefix are reserved for ACP (got '$value')"
+            }
+            return Unknown(value)
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object PermissionOptionKindSerializer : OpenStringEnumSerializer<PermissionOptionKind>(
+    serialName = "com.agentclientprotocol.model.v2.PermissionOptionKind",
+    knownValues = listOf(
+        PermissionOptionKind.AllowOnce,
+        PermissionOptionKind.AllowAlways,
+        PermissionOptionKind.RejectOnce,
+        PermissionOptionKind.RejectAlways,
+    ),
+    wireValue = PermissionOptionKind::value,
+    unknown = PermissionOptionKind::Unknown,
+)
+
+/**
+ * **UNSTABLE**
+ *
+ * This capability is not part of the spec yet, and may be removed or changed at any point.
+ *
+ * Well-known API protocol identifiers for LLM providers.
+ *
+ * Agents and clients MUST handle unknown protocol identifiers gracefully.
+ *
+ * This is an open enum: unrecognized wire values deserialize to [Unknown] instead of
+ * failing, so newer ACP variants and `_`-prefixed extensions degrade gracefully.
+ */
+@UnstableApi
+@Serializable(with = LlmProtocolSerializer::class)
+public sealed class LlmProtocol {
+    /**
+     * The wire-format string for this protocol.
+     */
+    public abstract val value: String
+
+    /**
+     * Anthropic API protocol.
+     */
+    public data object Anthropic : LlmProtocol() {
+        override val value: String = "anthropic"
+    }
+
+    /**
+     * OpenAI API protocol.
+     */
+    public data object OpenAi : LlmProtocol() {
+        override val value: String = "openai"
+    }
+
+    /**
+     * Azure OpenAI API protocol.
+     */
+    public data object Azure : LlmProtocol() {
+        override val value: String = "azure"
+    }
+
+    /**
+     * Google Vertex AI API protocol.
+     */
+    public data object Vertex : LlmProtocol() {
+        override val value: String = "vertex"
+    }
+
+    /**
+     * AWS Bedrock API protocol.
+     */
+    public data object Bedrock : LlmProtocol() {
+        override val value: String = "bedrock"
+    }
+
+    /**
+     * Custom or future protocol.
+     *
+     * Values beginning with `_` are reserved for implementation-specific extensions.
+     * Unknown values that do not begin with `_` are reserved for future ACP variants
+     * and MUST NOT be treated as custom extensions.
+     *
+     * Receivers that cannot act on an unknown protocol SHOULD preserve it when storing,
+     * replaying, proxying, or forwarding protocol data, and otherwise degrade gracefully
+     * according to the field's semantics.
+     */
+    public data class Unknown(override val value: String) : LlmProtocol()
+
+    public companion object {
+        /**
+         * Creates an implementation-specific extension protocol.
+         *
+         * Extension values must begin with `_` — all other values are reserved for ACP,
+         * including future ACP variants.
+         *
+         * @throws IllegalArgumentException if [value] does not begin with `_`
+         */
+        public fun extension(value: String): Unknown {
+            require(value.startsWith('_')) {
+                "Extension values must begin with '_'; values without the prefix are reserved for ACP (got '$value')"
+            }
+            return Unknown(value)
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object LlmProtocolSerializer : OpenStringEnumSerializer<LlmProtocol>(
+    serialName = "com.agentclientprotocol.model.v2.LlmProtocol",
+    knownValues = listOf(
+        LlmProtocol.Anthropic,
+        LlmProtocol.OpenAi,
+        LlmProtocol.Azure,
+        LlmProtocol.Vertex,
+        LlmProtocol.Bedrock,
+    ),
+    wireValue = LlmProtocol::value,
+    unknown = LlmProtocol::Unknown,
+)
+
+/**
+ * The outcome of a permission request.
+ *
+ * This is an open tagged union: an unrecognized `outcome` discriminator deserializes to
+ * [Unknown] with the full raw JSON preserved, so newer ACP variants and `_`-prefixed
+ * extensions degrade gracefully.
+ */
+@UnstableApi
+@Serializable(with = RequestPermissionOutcomeSerializer::class)
+public sealed class RequestPermissionOutcome {
+    /**
+     * Active session work was cancelled before the user responded.
+     *
+     * When a client sends a `session/cancel` notification to cancel active
+     * session work, it MUST respond to all pending `session/request_permission`
+     * requests with this `Cancelled` outcome.
+     *
+     * See protocol docs: [Cancellation](https://agentclientprotocol.com/protocol/prompt-lifecycle#cancellation)
+     */
+    @Serializable
+    public data object Cancelled : RequestPermissionOutcome()
+
+    /**
+     * The user selected one of the provided options.
+     */
+    @Serializable
+    public data class Selected(
+        val optionId: PermissionOptionId,
+        override val _meta: JsonElement? = null,
+    ) : RequestPermissionOutcome(), AcpWithMeta
+
+    /**
+     * Custom or future permission outcome.
+     *
+     * Discriminator values beginning with `_` are reserved for implementation-specific
+     * extensions. Unknown values that do not begin with `_` are reserved for future ACP
+     * variants and MUST NOT be treated as custom extensions.
+     *
+     * Agents that do not understand this outcome MUST NOT treat it as approval.
+     * [rawJson] holds the complete payload as received (including the discriminator), so
+     * re-serializing emits it byte-identically. Agents should preserve it when storing,
+     * replaying, proxying, or forwarding permission responses, and otherwise fail or
+     * decline the permission request according to policy.
+     */
+    public data class Unknown(val outcome: String, val rawJson: JsonObject) : RequestPermissionOutcome()
+}
+
+@OptIn(UnstableApi::class)
+internal object RequestPermissionOutcomeSerializer : OpenTaggedUnionSerializer<RequestPermissionOutcome>(
+    serialName = "com.agentclientprotocol.model.v2.RequestPermissionOutcome",
+    discriminatorKey = "outcome",
+    known = mapOf(
+        "cancelled" to RequestPermissionOutcome.Cancelled.serializer(),
+        "selected" to RequestPermissionOutcome.Selected.serializer(),
+    ),
+    discriminator = { value ->
+        when (value) {
+            is RequestPermissionOutcome.Cancelled -> "cancelled"
+            is RequestPermissionOutcome.Selected -> "selected"
+            is RequestPermissionOutcome.Unknown -> value.outcome
+        }
+    },
+    unknown = RequestPermissionOutcome::Unknown,
+    rawJson = { (it as? RequestPermissionOutcome.Unknown)?.rawJson },
+)

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/SessionConfig.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/SessionConfig.kt
@@ -1,0 +1,399 @@
+@file:Suppress("unused")
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.AcpWithMeta
+import com.agentclientprotocol.model.SessionConfigGroupId
+import com.agentclientprotocol.model.SessionConfigId
+import com.agentclientprotocol.model.SessionConfigSelectOption
+import com.agentclientprotocol.model.SessionConfigValueId
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * Semantic category for a session configuration option.
+ *
+ * This is intended to help clients distinguish broadly common selectors (e.g. model selector vs
+ * session mode selector vs thought/reasoning level) for UX purposes (keyboard shortcuts, icons,
+ * placement). It MUST NOT be required for correctness. Clients MUST handle missing or unknown
+ * categories gracefully.
+ *
+ * This is an open enum: unrecognized wire values deserialize to [Unknown] instead of
+ * failing, so newer ACP variants and `_`-prefixed extensions degrade gracefully.
+ */
+@UnstableApi
+@Serializable(with = SessionConfigOptionCategorySerializer::class)
+public sealed class SessionConfigOptionCategory {
+    /**
+     * The wire-format string for this category.
+     */
+    public abstract val value: String
+
+    /**
+     * Session mode selector.
+     */
+    public data object Mode : SessionConfigOptionCategory() {
+        override val value: String = "mode"
+    }
+
+    /**
+     * Model selector.
+     */
+    public data object Model : SessionConfigOptionCategory() {
+        override val value: String = "model"
+    }
+
+    /**
+     * Model-related configuration parameter.
+     */
+    public data object ModelConfig : SessionConfigOptionCategory() {
+        override val value: String = "model_config"
+    }
+
+    /**
+     * Thought/reasoning level selector.
+     */
+    public data object ThoughtLevel : SessionConfigOptionCategory() {
+        override val value: String = "thought_level"
+    }
+
+    /**
+     * Custom or future category.
+     *
+     * Values beginning with `_` are reserved for implementation-specific extensions.
+     * Unknown values that do not begin with `_` are reserved for future ACP variants
+     * and MUST NOT be treated as custom extensions.
+     *
+     * Receivers that cannot act on an unknown category SHOULD preserve it when storing,
+     * replaying, proxying, or forwarding protocol data, and otherwise degrade gracefully
+     * according to the field's semantics.
+     */
+    public data class Unknown(override val value: String) : SessionConfigOptionCategory()
+
+    public companion object {
+        /**
+         * Creates an implementation-specific extension category.
+         *
+         * Extension values must begin with `_` — all other values are reserved for ACP,
+         * including future ACP variants.
+         *
+         * @throws IllegalArgumentException if [value] does not begin with `_`
+         */
+        public fun extension(value: String): Unknown {
+            require(value.startsWith('_')) {
+                "Extension values must begin with '_'; values without the prefix are reserved for ACP (got '$value')"
+            }
+            return Unknown(value)
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object SessionConfigOptionCategorySerializer : OpenStringEnumSerializer<SessionConfigOptionCategory>(
+    serialName = "com.agentclientprotocol.model.v2.SessionConfigOptionCategory",
+    knownValues = listOf(
+        SessionConfigOptionCategory.Mode,
+        SessionConfigOptionCategory.Model,
+        SessionConfigOptionCategory.ModelConfig,
+        SessionConfigOptionCategory.ThoughtLevel,
+    ),
+    wireValue = SessionConfigOptionCategory::value,
+    unknown = SessionConfigOptionCategory::Unknown,
+)
+
+/**
+ * A group of options for a session configuration select.
+ *
+ * Unlike v1, the group identifier field is `groupId` on the wire (renamed from v1's
+ * `group`) and [name] is required.
+ */
+@UnstableApi
+@Serializable
+public data class SessionConfigSelectGroup(
+    val groupId: SessionConfigGroupId,
+    val name: String,
+    val options: List<SessionConfigSelectOption>,
+    override val _meta: JsonElement? = null,
+) : AcpWithMeta
+
+/**
+ * The options of a select-type session configuration option.
+ *
+ * Serialized as a plain JSON array; the shape of the first element decides between
+ * [Ungrouped] and [Grouped] (a `groupId` key marks a group). This union is untagged and
+ * stays **closed** in v2 — without a discriminator there is nothing safe to key a
+ * fallback on.
+ */
+@UnstableApi
+@Serializable(with = SessionConfigSelectOptionsSerializer::class)
+public sealed class SessionConfigSelectOptions {
+    /**
+     * A flat list of options with no grouping.
+     */
+    public data class Ungrouped(
+        val options: List<SessionConfigSelectOption>,
+    ) : SessionConfigSelectOptions()
+
+    /**
+     * A list of options grouped under headers.
+     */
+    public data class Grouped(
+        val groups: List<SessionConfigSelectGroup>,
+    ) : SessionConfigSelectOptions()
+}
+
+@OptIn(UnstableApi::class)
+internal object SessionConfigSelectOptionsSerializer : KSerializer<SessionConfigSelectOptions> {
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("com.agentclientprotocol.model.v2.SessionConfigSelectOptions")
+
+    override fun serialize(encoder: Encoder, value: SessionConfigSelectOptions) {
+        val jsonEncoder = encoder as JsonEncoder
+        val elements = when (value) {
+            is SessionConfigSelectOptions.Ungrouped -> value.options.map {
+                jsonEncoder.json.encodeToJsonElement(SessionConfigSelectOption.serializer(), it)
+            }
+            is SessionConfigSelectOptions.Grouped -> value.groups.map {
+                jsonEncoder.json.encodeToJsonElement(SessionConfigSelectGroup.serializer(), it)
+            }
+        }
+        jsonEncoder.encodeJsonElement(JsonArray(elements))
+    }
+
+    override fun deserialize(decoder: Decoder): SessionConfigSelectOptions {
+        val jsonDecoder = decoder as JsonDecoder
+        val array = jsonDecoder.decodeJsonElement().jsonArray
+
+        if (array.isEmpty()) return SessionConfigSelectOptions.Ungrouped(emptyList())
+
+        return if ("groupId" in array[0].jsonObject) {
+            SessionConfigSelectOptions.Grouped(
+                array.map { jsonDecoder.json.decodeFromJsonElement(SessionConfigSelectGroup.serializer(), it) },
+            )
+        } else {
+            SessionConfigSelectOptions.Ungrouped(
+                array.map { jsonDecoder.json.decodeFromJsonElement(SessionConfigSelectOption.serializer(), it) },
+            )
+        }
+    }
+}
+
+/**
+ * Type-specific payload of a [SessionConfigOption], flattened into the option object
+ * on the wire and discriminated by `type`.
+ *
+ * This is an open union: an unrecognized `type` deserializes to [Unknown] preserving
+ * its extra fields.
+ */
+@UnstableApi
+public sealed class SessionConfigKind {
+    /**
+     * Single-value selector (dropdown).
+     */
+    public data class Select(
+        val currentValue: SessionConfigValueId,
+        val options: SessionConfigSelectOptions,
+    ) : SessionConfigKind()
+
+    /**
+     * Boolean on/off toggle.
+     */
+    public data class Boolean(
+        val currentValue: kotlin.Boolean,
+    ) : SessionConfigKind()
+
+    /**
+     * Custom or future session configuration option payload.
+     *
+     * Type values beginning with `_` are reserved for implementation-specific
+     * extensions. Unknown values that do not begin with `_` are reserved for future ACP
+     * variants and MUST NOT be treated as custom extensions.
+     *
+     * [fields] holds the kind-specific payload as received, excluding the fields of the
+     * enclosing [SessionConfigOption]. Clients that do not understand this option type
+     * SHOULD preserve it when storing, replaying, proxying, or forwarding configuration
+     * data, and otherwise ignore the option or display it generically.
+     */
+    public data class Unknown(val type: String, val fields: JsonObject) : SessionConfigKind()
+}
+
+/**
+ * A session configuration option selector and its current state.
+ *
+ * Unlike v1, this is a struct with a flattened [kind] payload, and the identifier field
+ * is `configId` on the wire (renamed from v1's `id`).
+ */
+@UnstableApi
+@Serializable(with = SessionConfigOptionSerializer::class)
+public data class SessionConfigOption(
+    val configId: SessionConfigId,
+    val name: String,
+    val description: String? = null,
+    val category: SessionConfigOptionCategory? = null,
+    val kind: SessionConfigKind,
+    override val _meta: JsonElement? = null,
+) : AcpWithMeta
+
+@OptIn(UnstableApi::class)
+internal object SessionConfigOptionSerializer : KSerializer<SessionConfigOption> {
+    private val optionKeys = setOf("type", "configId", "name", "description", "category", "_meta")
+
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("com.agentclientprotocol.model.v2.SessionConfigOption")
+
+    override fun serialize(encoder: Encoder, value: SessionConfigOption) {
+        val jsonEncoder = encoder as JsonEncoder
+        val jsonObject = buildJsonObject {
+            put(
+                "type",
+                JsonPrimitive(
+                    when (val kind = value.kind) {
+                        is SessionConfigKind.Select -> "select"
+                        is SessionConfigKind.Boolean -> "boolean"
+                        is SessionConfigKind.Unknown -> kind.type
+                    },
+                ),
+            )
+            put("configId", JsonPrimitive(value.configId.value))
+            put("name", JsonPrimitive(value.name))
+            value.description?.let { put("description", JsonPrimitive(it)) }
+            value.category?.let { put("category", JsonPrimitive(it.value)) }
+            when (val kind = value.kind) {
+                is SessionConfigKind.Select -> {
+                    put("currentValue", JsonPrimitive(kind.currentValue.value))
+                    put(
+                        "options",
+                        jsonEncoder.json.encodeToJsonElement(SessionConfigSelectOptions.serializer(), kind.options),
+                    )
+                }
+                is SessionConfigKind.Boolean -> put("currentValue", JsonPrimitive(kind.currentValue))
+                is SessionConfigKind.Unknown -> kind.fields.forEach { (key, element) ->
+                    if (key !in optionKeys) put(key, element)
+                }
+            }
+            value._meta?.let { put("_meta", it) }
+        }
+        jsonEncoder.encodeJsonElement(jsonObject)
+    }
+
+    override fun deserialize(decoder: Decoder): SessionConfigOption {
+        val jsonDecoder = decoder as JsonDecoder
+        val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
+        val type = requireString(jsonObject, "type")
+        val kind = when (type) {
+            "select" -> SessionConfigKind.Select(
+                currentValue = SessionConfigValueId(requireString(jsonObject, "currentValue")),
+                options = jsonDecoder.json.decodeFromJsonElement(
+                    SessionConfigSelectOptions.serializer(),
+                    jsonObject["options"]
+                        ?: throw SerializationException("Missing 'options' in 'select' SessionConfigOption"),
+                ),
+            )
+            "boolean" -> SessionConfigKind.Boolean(
+                currentValue = (jsonObject["currentValue"] as? JsonPrimitive)?.booleanOrNull
+                    ?: throw SerializationException("Missing 'currentValue' in 'boolean' SessionConfigOption"),
+            )
+            else -> SessionConfigKind.Unknown(
+                type = type,
+                fields = JsonObject(jsonObject.filterKeys { it !in optionKeys }),
+            )
+        }
+        return SessionConfigOption(
+            configId = SessionConfigId(requireString(jsonObject, "configId")),
+            name = requireString(jsonObject, "name"),
+            description = (jsonObject["description"] as? JsonPrimitive)?.takeIf { it.isString }?.content,
+            category = (jsonObject["category"] as? JsonPrimitive)?.takeIf { it.isString }?.content?.let {
+                jsonDecoder.json.decodeFromJsonElement(SessionConfigOptionCategory.serializer(), JsonPrimitive(it))
+            },
+            kind = kind,
+            _meta = jsonObject["_meta"],
+        )
+    }
+
+    private fun requireString(jsonObject: JsonObject, key: String): String =
+        (jsonObject[key] as? JsonPrimitive)?.takeIf { it.isString }?.content
+            ?: throw SerializationException("Missing '$key' in SessionConfigOption")
+}
+
+/**
+ * The value of a session configuration option.
+ *
+ * Unlike v1's raw string-or-boolean, v2 values are tagged objects:
+ * `{"type":"id","value":…}` or `{"type":"boolean","value":…}`.
+ *
+ * This is an open tagged union: an unrecognized `type` discriminator deserializes to
+ * [Unknown] with the full raw JSON preserved, so newer ACP variants and `_`-prefixed
+ * extensions degrade gracefully.
+ */
+@UnstableApi
+@Serializable(with = SessionConfigOptionValueSerializer::class)
+public sealed class SessionConfigOptionValue {
+    /**
+     * A [SessionConfigValueId] string value, used for select-type options.
+     */
+    @Serializable
+    public data class Id(val value: SessionConfigValueId) : SessionConfigOptionValue()
+
+    /**
+     * A boolean value, used for boolean-type options.
+     */
+    @Serializable
+    public data class Boolean(val value: kotlin.Boolean) : SessionConfigOptionValue()
+
+    /**
+     * Custom or future session configuration option value.
+     *
+     * Discriminator values beginning with `_` are reserved for implementation-specific
+     * extensions. Unknown values that do not begin with `_` are reserved for future ACP
+     * variants and MUST NOT be treated as custom extensions.
+     *
+     * Even unknown values must carry a `value` payload — decoding fails otherwise.
+     * [rawJson] holds the complete payload as received (including the discriminator), so
+     * re-serializing emits it byte-identically.
+     */
+    public data class Unknown(
+        val type: String,
+        val value: JsonElement,
+        val rawJson: JsonObject,
+    ) : SessionConfigOptionValue()
+}
+
+@OptIn(UnstableApi::class)
+internal object SessionConfigOptionValueSerializer : OpenTaggedUnionSerializer<SessionConfigOptionValue>(
+    serialName = "com.agentclientprotocol.model.v2.SessionConfigOptionValue",
+    discriminatorKey = "type",
+    known = mapOf(
+        "id" to SessionConfigOptionValue.Id.serializer(),
+        "boolean" to SessionConfigOptionValue.Boolean.serializer(),
+    ),
+    discriminator = { value ->
+        when (value) {
+            is SessionConfigOptionValue.Id -> "id"
+            is SessionConfigOptionValue.Boolean -> "boolean"
+            is SessionConfigOptionValue.Unknown -> value.type
+        }
+    },
+    unknown = { type, rawJson ->
+        val value = rawJson["value"] ?: throw SerializationException("Missing 'value' in unknown SessionConfigOptionValue")
+        SessionConfigOptionValue.Unknown(type = type, value = value, rawJson = rawJson)
+    },
+    rawJson = { (it as? SessionConfigOptionValue.Unknown)?.rawJson },
+)

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/SessionUpdate.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/SessionUpdate.kt
@@ -1,0 +1,690 @@
+@file:Suppress("unused")
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.AcpWithMeta
+import com.agentclientprotocol.model.Cost
+import com.agentclientprotocol.model.MessageId
+import com.agentclientprotocol.model.Usage
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+
+// The SessionUpdate variants are named after their payloads. Inside
+// the sealed class those names resolve to the variants themselves, so the payload types get
+// file-local aliases. (An aliased `import` cannot be used here: these types live in this
+// same package, and importing them would shadow their own declarations below.)
+@OptIn(UnstableApi::class) private typealias UserMessagePayload = UserMessage
+@OptIn(UnstableApi::class) private typealias AgentMessagePayload = AgentMessage
+@OptIn(UnstableApi::class) private typealias AgentThoughtPayload = AgentThought
+@OptIn(UnstableApi::class) private typealias StateUpdatePayload = StateUpdate
+@OptIn(UnstableApi::class) private typealias ToolCallContentChunkPayload = ToolCallContentChunk
+@OptIn(UnstableApi::class) private typealias ToolCallUpdatePayload = ToolCallUpdate
+@OptIn(UnstableApi::class) private typealias PlanUpdatePayload = PlanUpdate
+@OptIn(UnstableApi::class) private typealias PlanRemovedPayload = PlanRemoved
+@OptIn(UnstableApi::class) private typealias AvailableCommandsUpdatePayload = AvailableCommandsUpdate
+@OptIn(UnstableApi::class) private typealias ConfigOptionUpdatePayload = ConfigOptionUpdate
+@OptIn(UnstableApi::class) private typealias SessionInfoUpdatePayload = SessionInfoUpdate
+@OptIn(UnstableApi::class) private typealias UsageUpdatePayload = UsageUpdate
+
+/**
+ * The input specification for a command.
+ *
+ * This is an open tagged union: an unrecognized `type` discriminator deserializes to
+ * [Unknown] with the full raw JSON preserved, so newer ACP variants and `_`-prefixed
+ * extensions degrade gracefully.
+ */
+@UnstableApi
+@Serializable(with = AvailableCommandInputSerializer::class)
+public sealed class AvailableCommandInput {
+    /**
+     * All text that was typed after the command name is provided as input.
+     *
+     * The v2 wire discriminator is `text` (renamed from v1's `unstructured`).
+     */
+    @Serializable
+    public data class Text(
+        val hint: String,
+        override val _meta: JsonElement? = null,
+    ) : AvailableCommandInput(), AcpWithMeta
+
+    /**
+     * Custom or future command input specification.
+     *
+     * Discriminator values beginning with `_` are reserved for implementation-specific
+     * extensions. Unknown values that do not begin with `_` are reserved for future ACP
+     * variants and MUST NOT be treated as custom extensions.
+     *
+     * [rawJson] holds the complete payload as received (including the discriminator), so
+     * re-serializing emits it byte-identically. Clients that do not understand this input
+     * type SHOULD preserve it when storing, replaying, proxying, or forwarding command
+     * metadata, and otherwise ignore the input specification or display the command
+     * without structured input.
+     */
+    public data class Unknown(val type: String, val rawJson: JsonObject) : AvailableCommandInput()
+}
+
+@OptIn(UnstableApi::class)
+internal object AvailableCommandInputSerializer : OpenTaggedUnionSerializer<AvailableCommandInput>(
+    serialName = "com.agentclientprotocol.model.v2.AvailableCommandInput",
+    discriminatorKey = "type",
+    known = mapOf(
+        "text" to AvailableCommandInput.Text.serializer(),
+    ),
+    discriminator = { value ->
+        when (value) {
+            is AvailableCommandInput.Text -> "text"
+            is AvailableCommandInput.Unknown -> value.type
+        }
+    },
+    unknown = AvailableCommandInput::Unknown,
+    rawJson = { (it as? AvailableCommandInput.Unknown)?.rawJson },
+)
+
+/**
+ * Information about a command.
+ *
+ * Same shape as v1's command, but [input] references the v2 [AvailableCommandInput].
+ */
+@UnstableApi
+@Serializable
+public data class AvailableCommand(
+    /**
+     * Command name (e.g., `create_plan`, `research_codebase`).
+     */
+    val name: String,
+    /**
+     * Human-readable description of what the command does.
+     */
+    val description: String,
+    /**
+     * Input for the command if required.
+     */
+    val input: AvailableCommandInput? = null,
+    override val _meta: JsonElement? = null,
+) : AcpWithMeta
+
+/**
+ * A streamed item of message content.
+ *
+ * Carries one [content] item of the message identified by [messageId]; all chunks of a
+ * message share the same ID, and a change in [messageId] starts a new message.
+ *
+ * Unlike v1's message chunks, [messageId] is required.
+ */
+@UnstableApi
+@Serializable
+public data class ContentChunk(
+    val messageId: MessageId,
+    val content: ContentBlock,
+    /**
+     * Chunk-scoped metadata; it describes this chunk, not the message as a whole.
+     */
+    override val _meta: JsonElement? = null,
+) : AcpWithMeta
+
+/**
+ * Available commands are ready or have changed.
+ *
+ * [availableCommands] is the full set of commands the agent can execute, replacing any
+ * previously reported set.
+ */
+@UnstableApi
+@Serializable
+public data class AvailableCommandsUpdate(
+    val availableCommands: List<AvailableCommand>,
+    override val _meta: JsonElement? = null,
+) : AcpWithMeta
+
+/**
+ * Session configuration options have been updated.
+ *
+ * [configOptions] is the full set of options and their current values, replacing any
+ * previously reported set.
+ */
+@UnstableApi
+@Serializable
+public data class ConfigOptionUpdate(
+    val configOptions: List<SessionConfigOption>,
+    override val _meta: JsonElement? = null,
+) : AcpWithMeta
+
+/**
+ * Context window and cost update for a session.
+ *
+ * Has no v1 counterpart: v1 reports token usage only in the prompt response.
+ */
+@UnstableApi
+@Serializable
+public data class UsageUpdate(
+    /**
+     * Tokens currently in context.
+     */
+    val used: Long,
+    /**
+     * Total context window size in tokens.
+     */
+    val size: Long,
+    /**
+     * Cumulative session cost.
+     */
+    val cost: Cost? = null,
+    override val _meta: JsonElement? = null,
+) : AcpWithMeta
+
+/**
+ * The agent's session state has changed.
+ *
+ * This is v2's mechanism for reporting session activity transitions. A `session/prompt`
+ * response only acknowledges that the prompt was accepted; agents report that processing
+ * started, that the session went idle, or that progress is blocked on user action through
+ * this update. v1 instead reported the outcome of a turn in the prompt response, so this
+ * union has no v1 counterpart.
+ *
+ * This is an open tagged union discriminated by `state`: an unrecognized state
+ * deserializes to [Unknown] with the full raw JSON preserved.
+ */
+@UnstableApi
+@Serializable(with = StateUpdateSerializer::class)
+public sealed class StateUpdate {
+    /**
+     * The agent is actively processing work in the session.
+     */
+    @Serializable
+    public data class Running(
+        override val _meta: JsonElement? = null,
+    ) : StateUpdate(), AcpWithMeta
+
+    /**
+     * The agent is not currently processing work in the session.
+     */
+    @Serializable
+    public data class Idle(
+        /**
+         * Why the agent stopped processing active session work.
+         *
+         * Omitted and `null` both mean no stop reason is being reported. Agents SHOULD
+         * include this when the idle transition ends active work.
+         */
+        val stopReason: StopReason? = null,
+        /**
+         * **UNSTABLE**
+         *
+         * This capability is not part of the spec yet, and may be removed or changed at
+         * any point.
+         *
+         * Token usage for completed session work. Omitted and `null` both mean no usage
+         * is being reported.
+         */
+        @property:UnstableApi
+        val usage: Usage? = null,
+        override val _meta: JsonElement? = null,
+    ) : StateUpdate(), AcpWithMeta
+
+    /**
+     * The agent is waiting on user action before it can continue.
+     */
+    @Serializable
+    public data class RequiresAction(
+        override val _meta: JsonElement? = null,
+    ) : StateUpdate(), AcpWithMeta
+
+    /**
+     * Custom or future session state.
+     *
+     * Discriminator values beginning with `_` are reserved for implementation-specific
+     * extensions. Unknown values that do not begin with `_` are reserved for future ACP
+     * variants and MUST NOT be treated as custom extensions.
+     *
+     * [rawJson] holds the complete payload as received (including the `state`
+     * discriminator), so re-serializing emits it byte-identically. Clients that do not
+     * understand this state SHOULD preserve it when storing, replaying, proxying, or
+     * forwarding session history.
+     */
+    public data class Unknown(val state: String, val rawJson: JsonObject) : StateUpdate()
+}
+
+@OptIn(UnstableApi::class)
+internal object StateUpdateSerializer : OpenTaggedUnionSerializer<StateUpdate>(
+    serialName = "com.agentclientprotocol.model.v2.StateUpdate",
+    discriminatorKey = "state",
+    known = mapOf(
+        "running" to StateUpdate.Running.serializer(),
+        "idle" to StateUpdate.Idle.serializer(),
+        "requires_action" to StateUpdate.RequiresAction.serializer(),
+    ),
+    discriminator = { value ->
+        when (value) {
+            is StateUpdate.Running -> "running"
+            is StateUpdate.Idle -> "idle"
+            is StateUpdate.RequiresAction -> "requires_action"
+            is StateUpdate.Unknown -> value.state
+        }
+    },
+    unknown = StateUpdate::Unknown,
+    rawJson = { (it as? StateUpdate.Unknown)?.rawJson },
+)
+
+/**
+ * An upsert for a message the user sent.
+ *
+ * Messages are keyed by [messageId]: repeated updates with the same ID patch the stored
+ * message. A [content] value **replaces** everything accumulated for the message so far,
+ * including content from earlier [ContentChunk]s; later chunks with the same [messageId]
+ * append to it again.
+ *
+ * Has no v1 counterpart — v1 streams message content only through chunks.
+ */
+@UnstableApi
+@Serializable(with = UserMessageSerializer::class)
+public data class UserMessage(
+    val messageId: MessageId,
+    /**
+     * Complete replacement content for this message.
+     */
+    val content: MaybeUndefined<List<ContentBlock>> = MaybeUndefined.Undefined,
+    val _meta: MaybeUndefined<JsonElement> = MaybeUndefined.Undefined,
+)
+
+/**
+ * An upsert for a message the agent sent.
+ *
+ * Same patch semantics as [UserMessage].
+ */
+@UnstableApi
+@Serializable(with = AgentMessageSerializer::class)
+public data class AgentMessage(
+    val messageId: MessageId,
+    /**
+     * Complete replacement content for this message.
+     */
+    val content: MaybeUndefined<List<ContentBlock>> = MaybeUndefined.Undefined,
+    val _meta: MaybeUndefined<JsonElement> = MaybeUndefined.Undefined,
+)
+
+/**
+ * An upsert for the agent's internal reasoning.
+ *
+ * Same patch semantics as [UserMessage].
+ */
+@UnstableApi
+@Serializable(with = AgentThoughtSerializer::class)
+public data class AgentThought(
+    val messageId: MessageId,
+    /**
+     * Complete replacement content for this message.
+     */
+    val content: MaybeUndefined<List<ContentBlock>> = MaybeUndefined.Undefined,
+    val _meta: MaybeUndefined<JsonElement> = MaybeUndefined.Undefined,
+)
+
+/**
+ * Shared serializer for the three message upserts, which have identical wire shapes.
+ *
+ * They need hand-written serializers because [MaybeUndefined] fields are decided by key
+ * presence rather than by field value; see [MaybeUndefined] for why.
+ */
+@OptIn(UnstableApi::class)
+internal abstract class MessageUpsertSerializer<T : Any>(
+    serialName: String,
+    private val construct: (
+        messageId: MessageId,
+        content: MaybeUndefined<List<ContentBlock>>,
+        meta: MaybeUndefined<JsonElement>,
+    ) -> T,
+    private val messageId: (T) -> MessageId,
+    private val content: (T) -> MaybeUndefined<List<ContentBlock>>,
+    private val meta: (T) -> MaybeUndefined<JsonElement>,
+) : KSerializer<T> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor(serialName)
+
+    override fun serialize(encoder: Encoder, value: T) {
+        val jsonEncoder = encoder as JsonEncoder
+        val json = jsonEncoder.json
+        jsonEncoder.encodeJsonElement(
+            buildJsonObject {
+                put("messageId", json.encodeToJsonElement(MessageId.serializer(), messageId(value)))
+                putMaybeUndefined(json, "content", content(value), ListSerializer(ContentBlock.serializer()))
+                putMaybeUndefined(json, "_meta", meta(value), JsonElement.serializer())
+            }
+        )
+    }
+
+    override fun deserialize(decoder: Decoder): T {
+        val jsonDecoder = decoder as JsonDecoder
+        val json = jsonDecoder.json
+        val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
+        val messageId = jsonObject["messageId"]
+            ?: throw SerializationException("Missing 'messageId' in ${descriptor.serialName}")
+        return construct(
+            json.decodeFromJsonElement(MessageId.serializer(), messageId),
+            jsonObject.decodeMaybeUndefinedList(json, "content", ContentBlock.serializer()),
+            jsonObject.decodeMaybeUndefined(json, "_meta", JsonElement.serializer()),
+        )
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object UserMessageSerializer : MessageUpsertSerializer<UserMessage>(
+    serialName = "com.agentclientprotocol.model.v2.UserMessage",
+    construct = ::UserMessage,
+    messageId = UserMessage::messageId,
+    content = UserMessage::content,
+    meta = UserMessage::_meta,
+)
+
+@OptIn(UnstableApi::class)
+internal object AgentMessageSerializer : MessageUpsertSerializer<AgentMessage>(
+    serialName = "com.agentclientprotocol.model.v2.AgentMessage",
+    construct = ::AgentMessage,
+    messageId = AgentMessage::messageId,
+    content = AgentMessage::content,
+    meta = AgentMessage::_meta,
+)
+
+@OptIn(UnstableApi::class)
+internal object AgentThoughtSerializer : MessageUpsertSerializer<AgentThought>(
+    serialName = "com.agentclientprotocol.model.v2.AgentThought",
+    construct = ::AgentThought,
+    messageId = AgentThought::messageId,
+    content = AgentThought::content,
+    meta = AgentThought::_meta,
+)
+
+/**
+ * Update to session metadata.
+ *
+ * All fields have patch semantics: an omitted field leaves the existing session info
+ * unchanged, and `null` clears the corresponding value. Unlike v1's session info update,
+ * clearing is therefore distinguishable from "no update".
+ */
+@UnstableApi
+@Serializable(with = SessionInfoUpdateSerializer::class)
+public data class SessionInfoUpdate(
+    /**
+     * Human-readable title for the session.
+     */
+    val title: MaybeUndefined<String> = MaybeUndefined.Undefined,
+    /**
+     * ISO 8601 timestamp of last activity.
+     */
+    val updatedAt: MaybeUndefined<String> = MaybeUndefined.Undefined,
+    val _meta: MaybeUndefined<JsonElement> = MaybeUndefined.Undefined,
+)
+
+@OptIn(UnstableApi::class)
+internal object SessionInfoUpdateSerializer : KSerializer<SessionInfoUpdate> {
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("com.agentclientprotocol.model.v2.SessionInfoUpdate")
+
+    override fun serialize(encoder: Encoder, value: SessionInfoUpdate) {
+        val jsonEncoder = encoder as JsonEncoder
+        val json = jsonEncoder.json
+        jsonEncoder.encodeJsonElement(
+            buildJsonObject {
+                putMaybeUndefined(json, "title", value.title, String.serializer())
+                putMaybeUndefined(json, "updatedAt", value.updatedAt, String.serializer())
+                putMaybeUndefined(json, "_meta", value._meta, JsonElement.serializer())
+            }
+        )
+    }
+
+    override fun deserialize(decoder: Decoder): SessionInfoUpdate {
+        val jsonDecoder = decoder as JsonDecoder
+        val json = jsonDecoder.json
+        val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
+        return SessionInfoUpdate(
+            title = jsonObject.decodeMaybeUndefined(json, "title", String.serializer()),
+            updatedAt = jsonObject.decodeMaybeUndefined(json, "updatedAt", String.serializer()),
+            _meta = jsonObject.decodeMaybeUndefined(json, "_meta", JsonElement.serializer()),
+        )
+    }
+}
+
+/**
+ * Different types of updates that can be sent during session processing.
+ *
+ * These updates provide real-time feedback about the agent's progress. Each variant wraps
+ * its payload, whose fields are flattened alongside the `sessionUpdate` discriminator on
+ * the wire.
+ *
+ * This is an open tagged union: an unrecognized `sessionUpdate` deserializes to [Unknown]
+ * with the full raw JSON preserved, so newer ACP variants and `_`-prefixed extensions
+ * degrade gracefully.
+ *
+ * Restructured from v1 in several ways:
+ * - v1's separate `tool_call` and `tool_call_update` collapse into [ToolCallUpdate].
+ * - Message content can now be sent as a whole ([UserMessage], [AgentMessage],
+ *   [AgentThought]) rather than only as chunks.
+ * - [StateUpdate] replaces reporting a turn's outcome through the prompt response.
+ * - Plans are identified by ID and can be removed.
+ *
+ * See protocol docs: [Agent Reports Output](https://agentclientprotocol.com/protocol/prompt-turn#3-agent-reports-output)
+ */
+@UnstableApi
+@Serializable(with = SessionUpdateSerializer::class)
+public sealed class SessionUpdate {
+    /**
+     * A chunk of the user's message being streamed.
+     */
+    public data class UserMessageChunk(val chunk: ContentChunk) : SessionUpdate()
+
+    /**
+     * A complete or partial upsert of the user's message.
+     */
+    public data class UserMessage(val message: UserMessagePayload) : SessionUpdate()
+
+    /**
+     * A chunk of the agent's response being streamed.
+     */
+    public data class AgentMessageChunk(val chunk: ContentChunk) : SessionUpdate()
+
+    /**
+     * A complete or partial upsert of the agent's message.
+     */
+    public data class AgentMessage(val message: AgentMessagePayload) : SessionUpdate()
+
+    /**
+     * A chunk of the agent's internal reasoning being streamed.
+     */
+    public data class AgentThoughtChunk(val chunk: ContentChunk) : SessionUpdate()
+
+    /**
+     * A complete or partial upsert of the agent's internal reasoning.
+     */
+    public data class AgentThought(val thought: AgentThoughtPayload) : SessionUpdate()
+
+    /**
+     * The agent's session state has changed.
+     */
+    public data class StateUpdate(val state: StateUpdatePayload) : SessionUpdate()
+
+    /**
+     * A chunk of tool call content, appended to the tool call's current content.
+     */
+    public data class ToolCallContentChunk(val chunk: ToolCallContentChunkPayload) : SessionUpdate()
+
+    /**
+     * A tool call was created or changed.
+     */
+    public data class ToolCallUpdate(val update: ToolCallUpdatePayload) : SessionUpdate()
+
+    /**
+     * A plan's content changed.
+     */
+    public data class PlanUpdate(val update: PlanUpdatePayload) : SessionUpdate()
+
+    /**
+     * **UNSTABLE**
+     *
+     * This capability is not part of the spec yet, and may be removed or changed at any point.
+     *
+     * A plan was removed.
+     */
+    public data class PlanRemoved(val removed: PlanRemovedPayload) : SessionUpdate()
+
+    /**
+     * Available commands are ready or have changed.
+     */
+    public data class AvailableCommandsUpdate(val update: AvailableCommandsUpdatePayload) : SessionUpdate()
+
+    /**
+     * Session configuration options have been updated.
+     */
+    public data class ConfigOptionUpdate(val update: ConfigOptionUpdatePayload) : SessionUpdate()
+
+    /**
+     * Session metadata has been updated.
+     */
+    public data class SessionInfoUpdate(val update: SessionInfoUpdatePayload) : SessionUpdate()
+
+    /**
+     * Context window and cost usage has been updated.
+     */
+    public data class UsageUpdate(val update: UsageUpdatePayload) : SessionUpdate()
+
+    /**
+     * Custom or future session update.
+     *
+     * Discriminator values beginning with `_` are reserved for implementation-specific
+     * extensions. Unknown values that do not begin with `_` are reserved for future ACP
+     * variants and MUST NOT be treated as custom extensions.
+     *
+     * [rawJson] holds the complete payload as received (including the discriminator), so
+     * re-serializing emits it byte-identically. Clients that do not understand this update
+     * SHOULD preserve it when storing, replaying, proxying, or forwarding session history,
+     * and otherwise ignore it.
+     */
+    public data class Unknown(val sessionUpdate: String, val rawJson: JsonObject) : SessionUpdate()
+}
+
+/**
+ * Adapts a payload serializer to the [SessionUpdate] variant that wraps it.
+ *
+ * Variants carry their payload rather than duplicating its fields, but the wire form
+ * flattens the payload next to the `sessionUpdate` discriminator, so the wrapper must
+ * serialize as the payload itself.
+ */
+@OptIn(UnstableApi::class)
+private class SessionUpdateVariantSerializer<P, V : SessionUpdate>(
+    variantName: String,
+    private val payload: KSerializer<P>,
+    private val wrap: (P) -> V,
+    private val unwrap: (V) -> P,
+) : KSerializer<V> {
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("com.agentclientprotocol.model.v2.SessionUpdate.$variantName")
+
+    override fun serialize(encoder: Encoder, value: V) {
+        val jsonEncoder = encoder as JsonEncoder
+        jsonEncoder.encodeJsonElement(jsonEncoder.json.encodeToJsonElement(payload, unwrap(value)))
+    }
+
+    override fun deserialize(decoder: Decoder): V {
+        val jsonDecoder = decoder as JsonDecoder
+        return wrap(jsonDecoder.json.decodeFromJsonElement(payload, jsonDecoder.decodeJsonElement()))
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object SessionUpdateSerializer : OpenTaggedUnionSerializer<SessionUpdate>(
+    serialName = "com.agentclientprotocol.model.v2.SessionUpdate",
+    discriminatorKey = "sessionUpdate",
+    known = mapOf(
+        "user_message_chunk" to SessionUpdateVariantSerializer(
+            "UserMessageChunk", ContentChunk.serializer(),
+            SessionUpdate::UserMessageChunk, SessionUpdate.UserMessageChunk::chunk,
+        ),
+        "user_message" to SessionUpdateVariantSerializer(
+            "UserMessage", UserMessagePayload.serializer(),
+            SessionUpdate::UserMessage, SessionUpdate.UserMessage::message,
+        ),
+        "agent_message_chunk" to SessionUpdateVariantSerializer(
+            "AgentMessageChunk", ContentChunk.serializer(),
+            SessionUpdate::AgentMessageChunk, SessionUpdate.AgentMessageChunk::chunk,
+        ),
+        "agent_message" to SessionUpdateVariantSerializer(
+            "AgentMessage", AgentMessagePayload.serializer(),
+            SessionUpdate::AgentMessage, SessionUpdate.AgentMessage::message,
+        ),
+        "agent_thought_chunk" to SessionUpdateVariantSerializer(
+            "AgentThoughtChunk", ContentChunk.serializer(),
+            SessionUpdate::AgentThoughtChunk, SessionUpdate.AgentThoughtChunk::chunk,
+        ),
+        "agent_thought" to SessionUpdateVariantSerializer(
+            "AgentThought", AgentThoughtPayload.serializer(),
+            SessionUpdate::AgentThought, SessionUpdate.AgentThought::thought,
+        ),
+        "state_update" to SessionUpdateVariantSerializer(
+            "StateUpdate", StateUpdatePayload.serializer(),
+            SessionUpdate::StateUpdate, SessionUpdate.StateUpdate::state,
+        ),
+        "tool_call_content_chunk" to SessionUpdateVariantSerializer(
+            "ToolCallContentChunk", ToolCallContentChunkPayload.serializer(),
+            SessionUpdate::ToolCallContentChunk, SessionUpdate.ToolCallContentChunk::chunk,
+        ),
+        "tool_call_update" to SessionUpdateVariantSerializer(
+            "ToolCallUpdate", ToolCallUpdatePayload.serializer(),
+            SessionUpdate::ToolCallUpdate, SessionUpdate.ToolCallUpdate::update,
+        ),
+        "plan_update" to SessionUpdateVariantSerializer(
+            "PlanUpdate", PlanUpdatePayload.serializer(),
+            SessionUpdate::PlanUpdate, SessionUpdate.PlanUpdate::update,
+        ),
+        "plan_removed" to SessionUpdateVariantSerializer(
+            "PlanRemoved", PlanRemovedPayload.serializer(),
+            SessionUpdate::PlanRemoved, SessionUpdate.PlanRemoved::removed,
+        ),
+        "available_commands_update" to SessionUpdateVariantSerializer(
+            "AvailableCommandsUpdate", AvailableCommandsUpdatePayload.serializer(),
+            SessionUpdate::AvailableCommandsUpdate, SessionUpdate.AvailableCommandsUpdate::update,
+        ),
+        "config_option_update" to SessionUpdateVariantSerializer(
+            "ConfigOptionUpdate", ConfigOptionUpdatePayload.serializer(),
+            SessionUpdate::ConfigOptionUpdate, SessionUpdate.ConfigOptionUpdate::update,
+        ),
+        "session_info_update" to SessionUpdateVariantSerializer(
+            "SessionInfoUpdate", SessionInfoUpdatePayload.serializer(),
+            SessionUpdate::SessionInfoUpdate, SessionUpdate.SessionInfoUpdate::update,
+        ),
+        "usage_update" to SessionUpdateVariantSerializer(
+            "UsageUpdate", UsageUpdatePayload.serializer(),
+            SessionUpdate::UsageUpdate, SessionUpdate.UsageUpdate::update,
+        ),
+    ),
+    discriminator = { value ->
+        when (value) {
+            is SessionUpdate.UserMessageChunk -> "user_message_chunk"
+            is SessionUpdate.UserMessage -> "user_message"
+            is SessionUpdate.AgentMessageChunk -> "agent_message_chunk"
+            is SessionUpdate.AgentMessage -> "agent_message"
+            is SessionUpdate.AgentThoughtChunk -> "agent_thought_chunk"
+            is SessionUpdate.AgentThought -> "agent_thought"
+            is SessionUpdate.StateUpdate -> "state_update"
+            is SessionUpdate.ToolCallContentChunk -> "tool_call_content_chunk"
+            is SessionUpdate.ToolCallUpdate -> "tool_call_update"
+            is SessionUpdate.PlanUpdate -> "plan_update"
+            is SessionUpdate.PlanRemoved -> "plan_removed"
+            is SessionUpdate.AvailableCommandsUpdate -> "available_commands_update"
+            is SessionUpdate.ConfigOptionUpdate -> "config_option_update"
+            is SessionUpdate.SessionInfoUpdate -> "session_info_update"
+            is SessionUpdate.UsageUpdate -> "usage_update"
+            is SessionUpdate.Unknown -> value.sessionUpdate
+        }
+    },
+    unknown = SessionUpdate::Unknown,
+    rawJson = { (it as? SessionUpdate.Unknown)?.rawJson },
+)

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/ToolCall.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/ToolCall.kt
@@ -1,0 +1,774 @@
+@file:Suppress("unused")
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.AcpWithMeta
+import com.agentclientprotocol.model.ToolCallId
+import com.agentclientprotocol.model.ToolCallLocation
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * Categories of tools that can be invoked.
+ *
+ * Tool kinds help clients choose appropriate icons and optimize how they
+ * display tool execution progress.
+ *
+ * This is an open enum: unrecognized wire values deserialize to [Unknown] instead of
+ * failing, so newer ACP variants and `_`-prefixed extensions degrade gracefully.
+ *
+ * See protocol docs: [Creating](https://agentclientprotocol.com/protocol/tool-calls#creating)
+ */
+@UnstableApi
+@Serializable(with = ToolKindSerializer::class)
+public sealed class ToolKind {
+    /**
+     * The wire-format string for this kind.
+     */
+    public abstract val value: String
+
+    /**
+     * Reading files or data.
+     */
+    public data object Read : ToolKind() {
+        override val value: String = "read"
+    }
+
+    /**
+     * Modifying files or content.
+     */
+    public data object Edit : ToolKind() {
+        override val value: String = "edit"
+    }
+
+    /**
+     * Removing files or data.
+     */
+    public data object Delete : ToolKind() {
+        override val value: String = "delete"
+    }
+
+    /**
+     * Moving or renaming files.
+     */
+    public data object Move : ToolKind() {
+        override val value: String = "move"
+    }
+
+    /**
+     * Searching for information.
+     */
+    public data object Search : ToolKind() {
+        override val value: String = "search"
+    }
+
+    /**
+     * Running commands or code.
+     */
+    public data object Execute : ToolKind() {
+        override val value: String = "execute"
+    }
+
+    /**
+     * Internal reasoning or planning.
+     */
+    public data object Think : ToolKind() {
+        override val value: String = "think"
+    }
+
+    /**
+     * Retrieving external data.
+     */
+    public data object Fetch : ToolKind() {
+        override val value: String = "fetch"
+    }
+
+    /**
+     * Switching the current session mode.
+     */
+    public data object SwitchMode : ToolKind() {
+        override val value: String = "switch_mode"
+    }
+
+    /**
+     * Other tool types (default).
+     *
+     * This is a *known* catch-all kind, distinct from [Unknown]: senders use it
+     * deliberately when no other category fits.
+     */
+    public data object Other : ToolKind() {
+        override val value: String = "other"
+    }
+
+    /**
+     * Custom or future tool kind.
+     *
+     * Values beginning with `_` are reserved for implementation-specific extensions.
+     * Unknown values that do not begin with `_` are reserved for future ACP variants
+     * and MUST NOT be treated as custom extensions.
+     *
+     * Receivers that cannot act on an unknown kind SHOULD preserve it when storing,
+     * replaying, proxying, or forwarding protocol data, and otherwise degrade gracefully
+     * according to the field's semantics.
+     */
+    public data class Unknown(override val value: String) : ToolKind()
+
+    public companion object {
+        /**
+         * Creates an implementation-specific extension kind.
+         *
+         * Extension values must begin with `_` — all other values are reserved for ACP,
+         * including future ACP variants.
+         *
+         * @throws IllegalArgumentException if [value] does not begin with `_`
+         */
+        public fun extension(value: String): Unknown {
+            require(value.startsWith('_')) {
+                "Extension values must begin with '_'; values without the prefix are reserved for ACP (got '$value')"
+            }
+            return Unknown(value)
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object ToolKindSerializer : OpenStringEnumSerializer<ToolKind>(
+    serialName = "com.agentclientprotocol.model.v2.ToolKind",
+    knownValues = listOf(
+        ToolKind.Read,
+        ToolKind.Edit,
+        ToolKind.Delete,
+        ToolKind.Move,
+        ToolKind.Search,
+        ToolKind.Execute,
+        ToolKind.Think,
+        ToolKind.Fetch,
+        ToolKind.SwitchMode,
+        ToolKind.Other,
+    ),
+    wireValue = ToolKind::value,
+    unknown = ToolKind::Unknown,
+)
+
+/**
+ * Execution status of a tool call.
+ *
+ * Tool calls progress through different statuses during their lifecycle.
+ *
+ * This is an open enum: unrecognized wire values deserialize to [Unknown] instead of
+ * failing, so newer ACP variants and `_`-prefixed extensions degrade gracefully.
+ *
+ * See protocol docs: [Status](https://agentclientprotocol.com/protocol/tool-calls#status)
+ */
+@UnstableApi
+@Serializable(with = ToolCallStatusSerializer::class)
+public sealed class ToolCallStatus {
+    /**
+     * The wire-format string for this status.
+     */
+    public abstract val value: String
+
+    /**
+     * The tool call hasn't started running yet because the input is either
+     * streaming or awaiting approval.
+     */
+    public data object Pending : ToolCallStatus() {
+        override val value: String = "pending"
+    }
+
+    /**
+     * The tool call is currently running.
+     */
+    public data object InProgress : ToolCallStatus() {
+        override val value: String = "in_progress"
+    }
+
+    /**
+     * The tool call completed successfully.
+     */
+    public data object Completed : ToolCallStatus() {
+        override val value: String = "completed"
+    }
+
+    /**
+     * The tool call failed with an error.
+     */
+    public data object Failed : ToolCallStatus() {
+        override val value: String = "failed"
+    }
+
+    /**
+     * Custom or future tool call status.
+     *
+     * Values beginning with `_` are reserved for implementation-specific extensions.
+     * Unknown values that do not begin with `_` are reserved for future ACP variants
+     * and MUST NOT be treated as custom extensions.
+     *
+     * Receivers that cannot act on an unknown status SHOULD preserve it when storing,
+     * replaying, proxying, or forwarding protocol data, and otherwise degrade gracefully
+     * according to the field's semantics.
+     */
+    public data class Unknown(override val value: String) : ToolCallStatus()
+
+    public companion object {
+        /**
+         * Creates an implementation-specific extension status.
+         *
+         * Extension values must begin with `_` — all other values are reserved for ACP,
+         * including future ACP variants.
+         *
+         * @throws IllegalArgumentException if [value] does not begin with `_`
+         */
+        public fun extension(value: String): Unknown {
+            require(value.startsWith('_')) {
+                "Extension values must begin with '_'; values without the prefix are reserved for ACP (got '$value')"
+            }
+            return Unknown(value)
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object ToolCallStatusSerializer : OpenStringEnumSerializer<ToolCallStatus>(
+    serialName = "com.agentclientprotocol.model.v2.ToolCallStatus",
+    knownValues = listOf(
+        ToolCallStatus.Pending,
+        ToolCallStatus.InProgress,
+        ToolCallStatus.Completed,
+        ToolCallStatus.Failed,
+    ),
+    wireValue = ToolCallStatus::value,
+    unknown = ToolCallStatus::Unknown,
+)
+
+/**
+ * Text patch format used by [ToolCallContent.Diff.patch].
+ *
+ * This is an open enum: unrecognized wire values deserialize to [Unknown] instead of
+ * failing, so newer ACP variants and `_`-prefixed extensions degrade gracefully.
+ */
+@UnstableApi
+@Serializable(with = DiffPatchFormatSerializer::class)
+public sealed class DiffPatchFormat {
+    /**
+     * The wire-format string for this patch format.
+     */
+    public abstract val value: String
+
+    /**
+     * Git patch format.
+     */
+    public data object GitPatch : DiffPatchFormat() {
+        override val value: String = "git_patch"
+    }
+
+    /**
+     * Custom or future diff format.
+     *
+     * Values beginning with `_` are reserved for implementation-specific extensions.
+     * Unknown values that do not begin with `_` are reserved for future ACP variants
+     * and MUST NOT be treated as custom extensions.
+     *
+     * Receivers that cannot act on an unknown format SHOULD preserve it when storing,
+     * replaying, proxying, or forwarding protocol data, and otherwise degrade gracefully
+     * according to the field's semantics.
+     */
+    public data class Unknown(override val value: String) : DiffPatchFormat()
+
+    public companion object {
+        /**
+         * Creates an implementation-specific extension format.
+         *
+         * Extension values must begin with `_` — all other values are reserved for ACP,
+         * including future ACP variants.
+         *
+         * @throws IllegalArgumentException if [value] does not begin with `_`
+         */
+        public fun extension(value: String): Unknown {
+            require(value.startsWith('_')) {
+                "Extension values must begin with '_'; values without the prefix are reserved for ACP (got '$value')"
+            }
+            return Unknown(value)
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object DiffPatchFormatSerializer : OpenStringEnumSerializer<DiffPatchFormat>(
+    serialName = "com.agentclientprotocol.model.v2.DiffPatchFormat",
+    knownValues = listOf(
+        DiffPatchFormat.GitPatch,
+    ),
+    wireValue = DiffPatchFormat::value,
+    unknown = DiffPatchFormat::Unknown,
+)
+
+/**
+ * Kind of file content represented by a diff change.
+ *
+ * This is an open enum: unrecognized wire values deserialize to [Unknown] instead of
+ * failing, so newer ACP variants and `_`-prefixed extensions degrade gracefully.
+ */
+@UnstableApi
+@Serializable(with = DiffFileTypeSerializer::class)
+public sealed class DiffFileType {
+    /**
+     * The wire-format string for this file type.
+     */
+    public abstract val value: String
+
+    /**
+     * Text content.
+     */
+    public data object Text : DiffFileType() {
+        override val value: String = "text"
+    }
+
+    /**
+     * Binary or otherwise non-text content.
+     */
+    public data object Binary : DiffFileType() {
+        override val value: String = "binary"
+    }
+
+    /**
+     * Directory entry.
+     */
+    public data object Directory : DiffFileType() {
+        override val value: String = "directory"
+    }
+
+    /**
+     * Symbolic link.
+     */
+    public data object Symlink : DiffFileType() {
+        override val value: String = "symlink"
+    }
+
+    /**
+     * Custom or future file type.
+     *
+     * Values beginning with `_` are reserved for implementation-specific extensions.
+     * Unknown values that do not begin with `_` are reserved for future ACP variants
+     * and MUST NOT be treated as custom extensions.
+     *
+     * Receivers that cannot act on an unknown file type SHOULD preserve it when storing,
+     * replaying, proxying, or forwarding protocol data, and otherwise degrade gracefully
+     * according to the field's semantics.
+     */
+    public data class Unknown(override val value: String) : DiffFileType()
+
+    public companion object {
+        /**
+         * Creates an implementation-specific extension file type.
+         *
+         * Extension values must begin with `_` — all other values are reserved for ACP,
+         * including future ACP variants.
+         *
+         * @throws IllegalArgumentException if [value] does not begin with `_`
+         */
+        public fun extension(value: String): Unknown {
+            require(value.startsWith('_')) {
+                "Extension values must begin with '_'; values without the prefix are reserved for ACP (got '$value')"
+            }
+            return Unknown(value)
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object DiffFileTypeSerializer : OpenStringEnumSerializer<DiffFileType>(
+    serialName = "com.agentclientprotocol.model.v2.DiffFileType",
+    knownValues = listOf(
+        DiffFileType.Text,
+        DiffFileType.Binary,
+        DiffFileType.Directory,
+        DiffFileType.Symlink,
+    ),
+    wireValue = DiffFileType::value,
+    unknown = DiffFileType::Unknown,
+)
+
+/**
+ * File operation for a [DiffChange].
+ *
+ * This is an open union discriminated by the flattened `operation` field: an
+ * unrecognized operation deserializes to [Unknown] preserving its extra fields.
+ */
+@UnstableApi
+public sealed class DiffChangeOperation {
+    /**
+     * A file was added.
+     */
+    public data class Add(val path: String) : DiffChangeOperation()
+
+    /**
+     * A file was deleted.
+     */
+    public data class Delete(val path: String) : DiffChangeOperation()
+
+    /**
+     * A file was modified in place.
+     */
+    public data class Modify(val path: String) : DiffChangeOperation()
+
+    /**
+     * A file was moved or renamed.
+     */
+    public data class Move(val oldPath: String, val path: String) : DiffChangeOperation()
+
+    /**
+     * A file was copied.
+     */
+    public data class Copy(val oldPath: String, val path: String) : DiffChangeOperation()
+
+    /**
+     * Custom or future file operation.
+     *
+     * Operation values beginning with `_` are reserved for implementation-specific
+     * extensions. Unknown values that do not begin with `_` are reserved for future ACP
+     * variants and MUST NOT be treated as custom extensions.
+     *
+     * [fields] holds the operation-specific payload as received, excluding the
+     * `operation`, `fileType`, `mimeType`, and `_meta` keys, which belong to the
+     * enclosing [DiffChange].
+     */
+    public data class Unknown(val operation: String, val fields: JsonObject) : DiffChangeOperation()
+}
+
+/**
+ * One file-level change described by a [ToolCallContent.Diff].
+ *
+ * Structured change metadata lets clients identify affected files and
+ * operations without parsing the text patch. The [operation] payload is
+ * flattened into this object on the wire.
+ */
+@UnstableApi
+@Serializable(with = DiffChangeSerializer::class)
+public data class DiffChange(
+    val operation: DiffChangeOperation,
+    val fileType: DiffFileType? = null,
+    val mimeType: String? = null,
+    override val _meta: JsonElement? = null,
+) : AcpWithMeta
+
+@OptIn(UnstableApi::class)
+internal object DiffChangeSerializer : KSerializer<DiffChange> {
+    private const val OPERATION = "operation"
+    private const val FILE_TYPE = "fileType"
+    private const val MIME_TYPE = "mimeType"
+    private const val META = "_meta"
+
+    private val changeKeys = setOf(OPERATION, FILE_TYPE, MIME_TYPE, META)
+
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("com.agentclientprotocol.model.v2.DiffChange")
+
+    override fun serialize(encoder: Encoder, value: DiffChange) {
+        val jsonEncoder = encoder as JsonEncoder
+        val jsonObject = buildJsonObject {
+            when (val operation = value.operation) {
+                is DiffChangeOperation.Add -> {
+                    put(OPERATION, JsonPrimitive("add"))
+                    put("path", JsonPrimitive(operation.path))
+                }
+                is DiffChangeOperation.Delete -> {
+                    put(OPERATION, JsonPrimitive("delete"))
+                    put("path", JsonPrimitive(operation.path))
+                }
+                is DiffChangeOperation.Modify -> {
+                    put(OPERATION, JsonPrimitive("modify"))
+                    put("path", JsonPrimitive(operation.path))
+                }
+                is DiffChangeOperation.Move -> {
+                    put(OPERATION, JsonPrimitive("move"))
+                    put("oldPath", JsonPrimitive(operation.oldPath))
+                    put("path", JsonPrimitive(operation.path))
+                }
+                is DiffChangeOperation.Copy -> {
+                    put(OPERATION, JsonPrimitive("copy"))
+                    put("oldPath", JsonPrimitive(operation.oldPath))
+                    put("path", JsonPrimitive(operation.path))
+                }
+                is DiffChangeOperation.Unknown -> {
+                    put(OPERATION, JsonPrimitive(operation.operation))
+                    operation.fields.forEach { (key, element) ->
+                        if (key !in changeKeys) put(key, element)
+                    }
+                }
+            }
+            value.fileType?.let { put(FILE_TYPE, JsonPrimitive(it.value)) }
+            value.mimeType?.let { put(MIME_TYPE, JsonPrimitive(it)) }
+            value._meta?.let { put(META, it) }
+        }
+        jsonEncoder.encodeJsonElement(jsonObject)
+    }
+
+    override fun deserialize(decoder: Decoder): DiffChange {
+        val jsonDecoder = decoder as JsonDecoder
+        val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
+        val operationValue = (jsonObject[OPERATION] as? JsonPrimitive)?.takeIf { it.isString }?.content
+            ?: throw SerializationException("Missing 'operation' discriminator in DiffChange")
+        val operation = when (operationValue) {
+            "add" -> DiffChangeOperation.Add(requirePath(jsonObject, operationValue))
+            "delete" -> DiffChangeOperation.Delete(requirePath(jsonObject, operationValue))
+            "modify" -> DiffChangeOperation.Modify(requirePath(jsonObject, operationValue))
+            "move" -> DiffChangeOperation.Move(
+                oldPath = requireString(jsonObject, "oldPath", operationValue),
+                path = requirePath(jsonObject, operationValue),
+            )
+            "copy" -> DiffChangeOperation.Copy(
+                oldPath = requireString(jsonObject, "oldPath", operationValue),
+                path = requirePath(jsonObject, operationValue),
+            )
+            else -> DiffChangeOperation.Unknown(
+                operation = operationValue,
+                fields = JsonObject(jsonObject.filterKeys { it !in changeKeys }),
+            )
+        }
+        val fileType = (jsonObject[FILE_TYPE] as? JsonPrimitive)?.takeIf { it.isString }?.content
+        val mimeType = (jsonObject[MIME_TYPE] as? JsonPrimitive)?.takeIf { it.isString }?.content
+        return DiffChange(
+            operation = operation,
+            fileType = fileType?.let { value ->
+                jsonDecoder.json.decodeFromJsonElement(DiffFileType.serializer(), JsonPrimitive(value))
+            },
+            mimeType = mimeType,
+            _meta = jsonObject[META],
+        )
+    }
+
+    private fun requirePath(jsonObject: JsonObject, operation: String): String =
+        requireString(jsonObject, "path", operation)
+
+    private fun requireString(jsonObject: JsonObject, key: String, operation: String): String =
+        (jsonObject[key] as? JsonPrimitive)?.takeIf { it.isString }?.content
+            ?: throw SerializationException("Missing '$key' in '$operation' DiffChange")
+}
+
+/**
+ * Renderable patch text.
+ */
+@UnstableApi
+@Serializable
+public data class DiffPatch(
+    val format: DiffPatchFormat = DiffPatchFormat.GitPatch,
+    val diff: String,
+)
+
+/**
+ * Content produced by a tool call.
+ *
+ * Tool calls can produce different types of content including
+ * standard content blocks (text, images) or file diffs.
+ *
+ * This is an open tagged union: an unrecognized `type` discriminator deserializes to
+ * [Unknown] with the full raw JSON preserved, so newer ACP variants and `_`-prefixed
+ * extensions degrade gracefully.
+ *
+ * No v1 conversions are provided for this union: v2 diffs (structured changes plus
+ * standard patch text) and v1 diffs (`oldText`/`newText`) have no faithful mutual
+ * representation, and v1's `terminal` variant was removed in v2. Convert the
+ * [Content] payload with the [ContentBlock] conversions where needed.
+ *
+ * See protocol docs: [Content](https://agentclientprotocol.com/protocol/tool-calls#content)
+ */
+@UnstableApi
+@Serializable(with = ToolCallContentSerializer::class)
+public sealed class ToolCallContent {
+    /**
+     * Standard content block (text, images, resources).
+     */
+    @Serializable
+    public data class Content(
+        val content: ContentBlock,
+        override val _meta: JsonElement? = null,
+    ) : ToolCallContent(), AcpWithMeta
+
+    /**
+     * File modification shown as a diff.
+     *
+     * Unlike v1's single-file `oldText`/`newText`, a v2 diff carries structured
+     * [changes] plus optional renderable [patch] text.
+     */
+    @Serializable
+    public data class Diff(
+        val changes: List<DiffChange>,
+        val patch: DiffPatch? = null,
+        override val _meta: JsonElement? = null,
+    ) : ToolCallContent(), AcpWithMeta
+
+    /**
+     * Custom or future tool call content.
+     *
+     * Discriminator values beginning with `_` are reserved for implementation-specific
+     * extensions. Unknown values that do not begin with `_` are reserved for future ACP
+     * variants and MUST NOT be treated as custom extensions.
+     *
+     * [rawJson] holds the complete payload as received (including the discriminator), so
+     * re-serializing emits it byte-identically. Receivers that do not understand this
+     * content type SHOULD preserve it when storing, replaying, proxying, or forwarding
+     * tool call output, and otherwise ignore it or display it generically.
+     */
+    public data class Unknown(val type: String, val rawJson: JsonObject) : ToolCallContent()
+}
+
+@OptIn(UnstableApi::class)
+internal object ToolCallContentSerializer : OpenTaggedUnionSerializer<ToolCallContent>(
+    serialName = "com.agentclientprotocol.model.v2.ToolCallContent",
+    discriminatorKey = "type",
+    known = mapOf(
+        "content" to ToolCallContent.Content.serializer(),
+        "diff" to ToolCallContent.Diff.serializer(),
+    ),
+    discriminator = { value ->
+        when (value) {
+            is ToolCallContent.Content -> "content"
+            is ToolCallContent.Diff -> "diff"
+            is ToolCallContent.Unknown -> value.type
+        }
+    },
+    unknown = ToolCallContent::Unknown,
+    rawJson = { (it as? ToolCallContent.Unknown)?.rawJson },
+)
+
+/**
+ * An upsert for a tool call that the language model has requested.
+ *
+ * Replaces v1's separate `tool_call` / `tool_call_update` variants: creation and update use
+ * the same `tool_call_update` session update, keyed by [toolCallId].
+ *
+ * Only [toolCallId] is required. Other fields have patch semantics via [MaybeUndefined]:
+ * an omitted field leaves the existing tool call value unchanged, `null` clears or unsets
+ * the value, and a concrete value replaces the previous value. For collection fields,
+ * concrete arrays replace the previous collection, and both `null` and `[]` clear it. When
+ * a client receives a tool call ID it has not seen before, omitted fields use client
+ * defaults.
+ *
+ * Deserialization degrades gracefully like the Rust schema: a malformed optional field
+ * decodes as [MaybeUndefined.Undefined] instead of failing, and malformed [content] or
+ * [locations] items are skipped.
+ *
+ * See protocol docs: [Tool Calls](https://agentclientprotocol.com/protocol/tool-calls)
+ */
+@UnstableApi
+@Serializable(with = ToolCallUpdateSerializer::class)
+public data class ToolCallUpdate(
+    val toolCallId: ToolCallId,
+    val title: MaybeUndefined<String> = MaybeUndefined.Undefined,
+    val kind: MaybeUndefined<ToolKind> = MaybeUndefined.Undefined,
+    val status: MaybeUndefined<ToolCallStatus> = MaybeUndefined.Undefined,
+    val content: MaybeUndefined<List<ToolCallContent>> = MaybeUndefined.Undefined,
+    val locations: MaybeUndefined<List<ToolCallLocation>> = MaybeUndefined.Undefined,
+    val rawInput: MaybeUndefined<JsonElement> = MaybeUndefined.Undefined,
+    val rawOutput: MaybeUndefined<JsonElement> = MaybeUndefined.Undefined,
+    val _meta: MaybeUndefined<JsonElement> = MaybeUndefined.Undefined,
+) {
+    /**
+     * Applies a later tool-call patch to this stored tool-call state.
+     *
+     * Fields set to [MaybeUndefined.Null] are preserved as [MaybeUndefined.Null] so callers
+     * can decide how to render an explicitly cleared value.
+     *
+     * @throws IllegalArgumentException if [update] targets a different [toolCallId]
+     */
+    public fun applyUpdate(update: ToolCallUpdate): ToolCallUpdate {
+        require(toolCallId == update.toolCallId) {
+            "Cannot apply update for tool call '${update.toolCallId}' to tool call '$toolCallId'"
+        }
+        return ToolCallUpdate(
+            toolCallId = toolCallId,
+            title = update.title.orPrevious(title),
+            kind = update.kind.orPrevious(kind),
+            status = update.status.orPrevious(status),
+            content = update.content.orPrevious(content),
+            locations = update.locations.orPrevious(locations),
+            rawInput = update.rawInput.orPrevious(rawInput),
+            rawOutput = update.rawOutput.orPrevious(rawOutput),
+            _meta = update._meta.orPrevious(_meta),
+        )
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object ToolCallUpdateSerializer : KSerializer<ToolCallUpdate> {
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("com.agentclientprotocol.model.v2.ToolCallUpdate")
+
+    override fun serialize(encoder: Encoder, value: ToolCallUpdate) {
+        val jsonEncoder = encoder as JsonEncoder
+        val json = jsonEncoder.json
+        jsonEncoder.encodeJsonElement(
+            buildJsonObject {
+                put("toolCallId", json.encodeToJsonElement(ToolCallId.serializer(), value.toolCallId))
+                putMaybeUndefined(json, "title", value.title, String.serializer())
+                putMaybeUndefined(json, "kind", value.kind, ToolKind.serializer())
+                putMaybeUndefined(json, "status", value.status, ToolCallStatus.serializer())
+                putMaybeUndefined(json, "content", value.content, ListSerializer(ToolCallContent.serializer()))
+                putMaybeUndefined(json, "locations", value.locations, ListSerializer(ToolCallLocation.serializer()))
+                putMaybeUndefined(json, "rawInput", value.rawInput, JsonElement.serializer())
+                putMaybeUndefined(json, "rawOutput", value.rawOutput, JsonElement.serializer())
+                putMaybeUndefined(json, "_meta", value._meta, JsonElement.serializer())
+            }
+        )
+    }
+
+    override fun deserialize(decoder: Decoder): ToolCallUpdate {
+        val jsonDecoder = decoder as JsonDecoder
+        val json = jsonDecoder.json
+        val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
+        val toolCallId = jsonObject["toolCallId"]
+            ?: throw SerializationException("Missing 'toolCallId' in ${descriptor.serialName}")
+        return ToolCallUpdate(
+            toolCallId = json.decodeFromJsonElement(ToolCallId.serializer(), toolCallId),
+            title = jsonObject.decodeMaybeUndefined(json, "title", String.serializer()),
+            kind = jsonObject.decodeMaybeUndefined(json, "kind", ToolKind.serializer()),
+            status = jsonObject.decodeMaybeUndefined(json, "status", ToolCallStatus.serializer()),
+            content = jsonObject.decodeMaybeUndefinedList(json, "content", ToolCallContent.serializer()),
+            locations = jsonObject.decodeMaybeUndefinedList(json, "locations", ToolCallLocation.serializer()),
+            rawInput = jsonObject.decodeMaybeUndefined(json, "rawInput", JsonElement.serializer()),
+            rawOutput = jsonObject.decodeMaybeUndefined(json, "rawOutput", JsonElement.serializer()),
+            _meta = jsonObject.decodeMaybeUndefined(json, "_meta", JsonElement.serializer()),
+        )
+    }
+}
+
+/**
+ * A streamed item of tool-call content.
+ *
+ * A chunk appends one [ToolCallContent] item to the content already streamed for
+ * [toolCallId]. Agents that need to replace the whole collection instead send
+ * [ToolCallUpdate.content].
+ *
+ * Has no v1 counterpart: v1 reports tool call output by resending the full content
+ * collection on every `tool_call_update`.
+ *
+ * See protocol docs: [Tool Calls](https://agentclientprotocol.com/protocol/tool-calls)
+ */
+@UnstableApi
+@Serializable
+public data class ToolCallContentChunk(
+    val toolCallId: ToolCallId,
+    val content: ToolCallContent,
+    /**
+     * Chunk-scoped metadata; it describes this chunk, not the tool call as a whole.
+     */
+    override val _meta: JsonElement? = null,
+) : AcpWithMeta

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/Types.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/Types.kt
@@ -1,0 +1,76 @@
+@file:Suppress("unused")
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import kotlinx.serialization.Serializable
+
+/**
+ * The sender or recipient of messages and data in a conversation.
+ *
+ * This is an open enum: unrecognized wire values deserialize to [Unknown] instead of
+ * failing, so newer ACP variants and `_`-prefixed extensions degrade gracefully.
+ */
+@UnstableApi
+@Serializable(with = RoleSerializer::class)
+public sealed class Role {
+    /**
+     * The wire-format string for this role.
+     */
+    public abstract val value: String
+
+    /**
+     * The assistant side of a conversation.
+     */
+    public data object Assistant : Role() {
+        override val value: String = "assistant"
+    }
+
+    /**
+     * The user side of a conversation.
+     */
+    public data object User : Role() {
+        override val value: String = "user"
+    }
+
+    /**
+     * Custom or future role.
+     *
+     * Values beginning with `_` are reserved for implementation-specific extensions.
+     * Unknown values that do not begin with `_` are reserved for future ACP variants
+     * and MUST NOT be treated as custom extensions.
+     *
+     * Receivers that cannot act on an unknown role SHOULD preserve it when storing,
+     * replaying, proxying, or forwarding protocol data, and otherwise degrade gracefully
+     * according to the field's semantics.
+     */
+    public data class Unknown(override val value: String) : Role()
+
+    public companion object {
+        /**
+         * Creates an implementation-specific extension role.
+         *
+         * Extension values must begin with `_` — all other values are reserved for ACP,
+         * including future ACP variants.
+         *
+         * @throws IllegalArgumentException if [value] does not begin with `_`
+         */
+        public fun extension(value: String): Unknown {
+            require(value.startsWith('_')) {
+                "Extension values must begin with '_'; values without the prefix are reserved for ACP (got '$value')"
+            }
+            return Unknown(value)
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object RoleSerializer : OpenStringEnumSerializer<Role>(
+    serialName = "com.agentclientprotocol.model.v2.Role",
+    knownValues = listOf(
+        Role.Assistant,
+        Role.User,
+    ),
+    wireValue = Role::value,
+    unknown = Role::Unknown,
+)

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/ContentConversions.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/ContentConversions.kt
@@ -1,0 +1,178 @@
+@file:Suppress("unused")
+
+package com.agentclientprotocol.model.v2.conversion
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.Annotations as V1Annotations
+import com.agentclientprotocol.model.ContentBlock as V1ContentBlock
+import com.agentclientprotocol.model.EmbeddedResourceResource as V1EmbeddedResourceResource
+import com.agentclientprotocol.model.v2.Annotations
+import com.agentclientprotocol.model.v2.ContentBlock
+import com.agentclientprotocol.model.v2.EmbeddedResourceResource
+
+/**
+ * Converts these v2 annotations to their v1 equivalent.
+ *
+ * This conversion is total: audience roles that have no v1 representation are
+ * skipped rather than failing — annotations are display hints, not semantics.
+ */
+@UnstableApi
+public fun Annotations.toV1(): V1Annotations = V1Annotations(
+    audience = audience?.mapNotNull { role ->
+        try {
+            role.toV1()
+        } catch (_: ProtocolConversionException) {
+            null
+        }
+    },
+    priority = priority,
+    lastModified = lastModified,
+    _meta = _meta,
+)
+
+/**
+ * Converts these v1 annotations to their v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1Annotations.toV2(): Annotations = Annotations(
+    audience = audience?.map { it.toV2() },
+    priority = priority,
+    lastModified = lastModified,
+    _meta = _meta,
+)
+
+/**
+ * Converts this v2 embedded resource to its v1 equivalent.
+ *
+ * This conversion is total: the v1 and v2 shapes are identical.
+ */
+@UnstableApi
+public fun EmbeddedResourceResource.toV1(): V1EmbeddedResourceResource = when (this) {
+    is EmbeddedResourceResource.TextResourceContents -> V1EmbeddedResourceResource.TextResourceContents(
+        text = text,
+        uri = uri,
+        mimeType = mimeType,
+        _meta = _meta,
+    )
+    is EmbeddedResourceResource.BlobResourceContents -> V1EmbeddedResourceResource.BlobResourceContents(
+        blob = blob,
+        uri = uri,
+        mimeType = mimeType,
+        _meta = _meta,
+    )
+}
+
+/**
+ * Converts this v1 embedded resource to its v2 equivalent.
+ *
+ * This conversion is total: the v1 and v2 shapes are identical.
+ */
+@UnstableApi
+public fun V1EmbeddedResourceResource.toV2(): EmbeddedResourceResource = when (this) {
+    is V1EmbeddedResourceResource.TextResourceContents -> EmbeddedResourceResource.TextResourceContents(
+        text = text,
+        uri = uri,
+        mimeType = mimeType,
+        _meta = _meta,
+    )
+    is V1EmbeddedResourceResource.BlobResourceContents -> EmbeddedResourceResource.BlobResourceContents(
+        blob = blob,
+        uri = uri,
+        mimeType = mimeType,
+        _meta = _meta,
+    )
+}
+
+/**
+ * Converts this v2 content block to its v1 equivalent.
+ *
+ * @throws ProtocolConversionException if this is an [ContentBlock.Unknown] block, or a
+ * [ContentBlock.ResourceLink] with non-empty `icons` — v1 cannot represent either
+ * without data loss
+ */
+@UnstableApi
+public fun ContentBlock.toV1(): V1ContentBlock = when (this) {
+    is ContentBlock.Text -> V1ContentBlock.Text(
+        text = text,
+        annotations = annotations?.toV1(),
+        _meta = _meta,
+    )
+    is ContentBlock.Image -> V1ContentBlock.Image(
+        data = data,
+        mimeType = mimeType,
+        uri = uri,
+        annotations = annotations?.toV1(),
+        _meta = _meta,
+    )
+    is ContentBlock.Audio -> V1ContentBlock.Audio(
+        data = data,
+        mimeType = mimeType,
+        annotations = annotations?.toV1(),
+        _meta = _meta,
+    )
+    is ContentBlock.ResourceLink -> {
+        if (!icons.isNullOrEmpty()) {
+            throw ProtocolConversionException("v2 ResourceLink.icons cannot be represented in v1")
+        }
+        V1ContentBlock.ResourceLink(
+            name = name,
+            uri = uri,
+            description = description,
+            mimeType = mimeType,
+            size = size,
+            title = title,
+            annotations = annotations?.toV1(),
+            _meta = _meta,
+        )
+    }
+    is ContentBlock.Resource -> V1ContentBlock.Resource(
+        resource = resource.toV1(),
+        annotations = annotations?.toV1(),
+        _meta = _meta,
+    )
+    is ContentBlock.Unknown -> throw unknownV2EnumVariant("ContentBlock", type)
+}
+
+/**
+ * Converts this v1 content block to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1ContentBlock.toV2(): ContentBlock = when (this) {
+    is V1ContentBlock.Text -> ContentBlock.Text(
+        text = text,
+        annotations = annotations?.toV2(),
+        _meta = _meta,
+    )
+    is V1ContentBlock.Image -> ContentBlock.Image(
+        data = data,
+        mimeType = mimeType,
+        uri = uri,
+        annotations = annotations?.toV2(),
+        _meta = _meta,
+    )
+    is V1ContentBlock.Audio -> ContentBlock.Audio(
+        data = data,
+        mimeType = mimeType,
+        annotations = annotations?.toV2(),
+        _meta = _meta,
+    )
+    is V1ContentBlock.ResourceLink -> ContentBlock.ResourceLink(
+        name = name,
+        uri = uri,
+        description = description,
+        mimeType = mimeType,
+        size = size,
+        title = title,
+        annotations = annotations?.toV2(),
+        _meta = _meta,
+    )
+    is V1ContentBlock.Resource -> ContentBlock.Resource(
+        resource = resource.toV2(),
+        annotations = annotations?.toV2(),
+        _meta = _meta,
+    )
+}

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/ElicitationConversions.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/ElicitationConversions.kt
@@ -1,0 +1,222 @@
+@file:Suppress("unused")
+
+package com.agentclientprotocol.model.v2.conversion
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.TitledMultiSelectItems
+import com.agentclientprotocol.model.UntitledMultiSelectItems
+import com.agentclientprotocol.model.ElicitationAction as V1ElicitationAction
+import com.agentclientprotocol.model.ElicitationPropertySchema as V1ElicitationPropertySchema
+import com.agentclientprotocol.model.ElicitationSchema as V1ElicitationSchema
+import com.agentclientprotocol.model.MultiSelectItems as V1MultiSelectItems
+import com.agentclientprotocol.model.StringFormat as V1StringFormat
+import com.agentclientprotocol.model.v2.ElicitationAction
+import com.agentclientprotocol.model.v2.ElicitationPropertySchema
+import com.agentclientprotocol.model.v2.ElicitationSchema
+import com.agentclientprotocol.model.v2.MultiSelectItems
+import com.agentclientprotocol.model.v2.StringFormat
+
+/**
+ * Converts this v2 format to its v1 equivalent.
+ *
+ * @throws ProtocolConversionException if this is an [StringFormat.Unknown] value,
+ * which cannot be represented in v1 without data loss
+ */
+@UnstableApi
+public fun StringFormat.toV1(): V1StringFormat = when (this) {
+    StringFormat.Email -> V1StringFormat.EMAIL
+    StringFormat.Uri -> V1StringFormat.URI
+    StringFormat.Date -> V1StringFormat.DATE
+    StringFormat.DateTime -> V1StringFormat.DATE_TIME
+    is StringFormat.Unknown -> throw unknownV2EnumVariant("StringFormat", value)
+}
+
+/**
+ * Converts this v1 format to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1StringFormat.toV2(): StringFormat = when (this) {
+    V1StringFormat.EMAIL -> StringFormat.Email
+    V1StringFormat.URI -> StringFormat.Uri
+    V1StringFormat.DATE -> StringFormat.Date
+    V1StringFormat.DATE_TIME -> StringFormat.DateTime
+}
+
+/**
+ * Converts these v2 multi-select items to their v1 equivalent.
+ *
+ * @throws ProtocolConversionException if this is an [MultiSelectItems.Unknown] value,
+ * which cannot be represented in v1 without data loss
+ */
+@UnstableApi
+public fun MultiSelectItems.toV1(): V1MultiSelectItems = when (this) {
+    is MultiSelectItems.StringItems ->
+        V1MultiSelectItems.Untitled(UntitledMultiSelectItems(values = values))
+    is MultiSelectItems.Titled ->
+        V1MultiSelectItems.Titled(TitledMultiSelectItems(options = options))
+    is MultiSelectItems.Unknown -> throw unknownV2EnumVariant("MultiSelectItems", type)
+}
+
+/**
+ * Converts these v1 multi-select items to their v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1MultiSelectItems.toV2(): MultiSelectItems = when (this) {
+    is V1MultiSelectItems.Untitled -> MultiSelectItems.StringItems(values = items.values)
+    is V1MultiSelectItems.Titled -> MultiSelectItems.Titled(options = items.options)
+}
+
+/**
+ * Converts this v2 property schema to its v1 equivalent.
+ *
+ * @throws ProtocolConversionException if this is an [ElicitationPropertySchema.Unknown]
+ * schema, or a nested value ([StringFormat.Unknown], [MultiSelectItems.Unknown]) has no
+ * v1 representation
+ */
+@UnstableApi
+public fun ElicitationPropertySchema.toV1(): V1ElicitationPropertySchema = when (this) {
+    is ElicitationPropertySchema.StringProperty -> V1ElicitationPropertySchema.StringProperty(
+        title = title,
+        description = description,
+        minLength = minLength,
+        maxLength = maxLength,
+        pattern = pattern,
+        format = format?.toV1(),
+        default = default,
+        enumValues = enumValues,
+        oneOf = oneOf,
+    )
+    is ElicitationPropertySchema.NumberProperty -> V1ElicitationPropertySchema.NumberProperty(
+        title = title,
+        description = description,
+        minimum = minimum,
+        maximum = maximum,
+        default = default,
+    )
+    is ElicitationPropertySchema.IntegerProperty -> V1ElicitationPropertySchema.IntegerProperty(
+        title = title,
+        description = description,
+        minimum = minimum,
+        maximum = maximum,
+        default = default,
+    )
+    is ElicitationPropertySchema.BooleanProperty -> V1ElicitationPropertySchema.BooleanProperty(
+        title = title,
+        description = description,
+        default = default,
+    )
+    is ElicitationPropertySchema.ArrayProperty -> V1ElicitationPropertySchema.ArrayProperty(
+        title = title,
+        description = description,
+        minItems = minItems,
+        maxItems = maxItems,
+        items = items.toV1(),
+        default = default,
+    )
+    is ElicitationPropertySchema.Unknown -> throw unknownV2EnumVariant("ElicitationPropertySchema", type)
+}
+
+/**
+ * Converts this v1 property schema to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1ElicitationPropertySchema.toV2(): ElicitationPropertySchema = when (this) {
+    is V1ElicitationPropertySchema.StringProperty -> ElicitationPropertySchema.StringProperty(
+        title = title,
+        description = description,
+        minLength = minLength,
+        maxLength = maxLength,
+        pattern = pattern,
+        format = format?.toV2(),
+        default = default,
+        enumValues = enumValues,
+        oneOf = oneOf,
+    )
+    is V1ElicitationPropertySchema.NumberProperty -> ElicitationPropertySchema.NumberProperty(
+        title = title,
+        description = description,
+        minimum = minimum,
+        maximum = maximum,
+        default = default,
+    )
+    is V1ElicitationPropertySchema.IntegerProperty -> ElicitationPropertySchema.IntegerProperty(
+        title = title,
+        description = description,
+        minimum = minimum,
+        maximum = maximum,
+        default = default,
+    )
+    is V1ElicitationPropertySchema.BooleanProperty -> ElicitationPropertySchema.BooleanProperty(
+        title = title,
+        description = description,
+        default = default,
+    )
+    is V1ElicitationPropertySchema.ArrayProperty -> ElicitationPropertySchema.ArrayProperty(
+        title = title,
+        description = description,
+        minItems = minItems,
+        maxItems = maxItems,
+        items = items.toV2(),
+        default = default,
+    )
+}
+
+/**
+ * Converts this v2 elicitation schema to its v1 equivalent.
+ *
+ * @throws ProtocolConversionException if a nested property schema has no v1 representation
+ */
+@UnstableApi
+public fun ElicitationSchema.toV1(): V1ElicitationSchema = V1ElicitationSchema(
+    type = type,
+    title = title,
+    properties = properties.mapValues { (_, property) -> property.toV1() },
+    required = required,
+    description = description,
+)
+
+/**
+ * Converts this v1 elicitation schema to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1ElicitationSchema.toV2(): ElicitationSchema = ElicitationSchema(
+    type = type,
+    title = title,
+    properties = properties.mapValues { (_, property) -> property.toV2() },
+    required = required,
+    description = description,
+)
+
+/**
+ * Converts this v2 action to its v1 equivalent.
+ *
+ * @throws ProtocolConversionException if this is an [ElicitationAction.Unknown] action,
+ * which cannot be represented in v1 without data loss
+ */
+@UnstableApi
+public fun ElicitationAction.toV1(): V1ElicitationAction = when (this) {
+    is ElicitationAction.Accept -> V1ElicitationAction.Accept(content = content)
+    is ElicitationAction.Decline -> V1ElicitationAction.Decline
+    is ElicitationAction.Cancel -> V1ElicitationAction.Cancel
+    is ElicitationAction.Unknown -> throw unknownV2EnumVariant("ElicitationAction", action)
+}
+
+/**
+ * Converts this v1 action to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1ElicitationAction.toV2(): ElicitationAction = when (this) {
+    is V1ElicitationAction.Accept -> ElicitationAction.Accept(content = content)
+    is V1ElicitationAction.Decline -> ElicitationAction.Decline
+    is V1ElicitationAction.Cancel -> ElicitationAction.Cancel
+}

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/NesConversions.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/NesConversions.kt
@@ -1,0 +1,167 @@
+@file:Suppress("unused")
+
+package com.agentclientprotocol.model.v2.conversion
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.NesDiagnosticSeverity as V1NesDiagnosticSeverity
+import com.agentclientprotocol.model.NesRejectReason as V1NesRejectReason
+import com.agentclientprotocol.model.NesSuggestion as V1NesSuggestion
+import com.agentclientprotocol.model.NesTriggerKind as V1NesTriggerKind
+import com.agentclientprotocol.model.v2.NesDiagnosticSeverity
+import com.agentclientprotocol.model.v2.NesRejectReason
+import com.agentclientprotocol.model.v2.NesSuggestion
+import com.agentclientprotocol.model.v2.NesTriggerKind
+
+/**
+ * Converts this v2 trigger kind to its v1 equivalent.
+ *
+ * @throws ProtocolConversionException if this is an [NesTriggerKind.Unknown] value,
+ * which cannot be represented in v1 without data loss
+ */
+@UnstableApi
+public fun NesTriggerKind.toV1(): V1NesTriggerKind = when (this) {
+    NesTriggerKind.Automatic -> V1NesTriggerKind.AUTOMATIC
+    NesTriggerKind.Diagnostic -> V1NesTriggerKind.DIAGNOSTIC
+    NesTriggerKind.Manual -> V1NesTriggerKind.MANUAL
+    is NesTriggerKind.Unknown -> throw unknownV2EnumVariant("NesTriggerKind", value)
+}
+
+/**
+ * Converts this v1 trigger kind to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1NesTriggerKind.toV2(): NesTriggerKind = when (this) {
+    V1NesTriggerKind.AUTOMATIC -> NesTriggerKind.Automatic
+    V1NesTriggerKind.DIAGNOSTIC -> NesTriggerKind.Diagnostic
+    V1NesTriggerKind.MANUAL -> NesTriggerKind.Manual
+}
+
+/**
+ * Converts this v2 reject reason to its v1 equivalent.
+ *
+ * @throws ProtocolConversionException if this is an [NesRejectReason.Unknown] value,
+ * which cannot be represented in v1 without data loss
+ */
+@UnstableApi
+public fun NesRejectReason.toV1(): V1NesRejectReason = when (this) {
+    NesRejectReason.Rejected -> V1NesRejectReason.REJECTED
+    NesRejectReason.Ignored -> V1NesRejectReason.IGNORED
+    NesRejectReason.Replaced -> V1NesRejectReason.REPLACED
+    NesRejectReason.Cancelled -> V1NesRejectReason.CANCELLED
+    is NesRejectReason.Unknown -> throw unknownV2EnumVariant("NesRejectReason", value)
+}
+
+/**
+ * Converts this v1 reject reason to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1NesRejectReason.toV2(): NesRejectReason = when (this) {
+    V1NesRejectReason.REJECTED -> NesRejectReason.Rejected
+    V1NesRejectReason.IGNORED -> NesRejectReason.Ignored
+    V1NesRejectReason.REPLACED -> NesRejectReason.Replaced
+    V1NesRejectReason.CANCELLED -> NesRejectReason.Cancelled
+}
+
+/**
+ * Converts this v2 severity to its v1 equivalent.
+ *
+ * @throws ProtocolConversionException if this is an [NesDiagnosticSeverity.Unknown] value,
+ * which cannot be represented in v1 without data loss
+ */
+@UnstableApi
+public fun NesDiagnosticSeverity.toV1(): V1NesDiagnosticSeverity = when (this) {
+    NesDiagnosticSeverity.Error -> V1NesDiagnosticSeverity.ERROR
+    NesDiagnosticSeverity.Warning -> V1NesDiagnosticSeverity.WARNING
+    NesDiagnosticSeverity.Information -> V1NesDiagnosticSeverity.INFORMATION
+    NesDiagnosticSeverity.Hint -> V1NesDiagnosticSeverity.HINT
+    is NesDiagnosticSeverity.Unknown -> throw unknownV2EnumVariant("NesDiagnosticSeverity", value)
+}
+
+/**
+ * Converts this v1 severity to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1NesDiagnosticSeverity.toV2(): NesDiagnosticSeverity = when (this) {
+    V1NesDiagnosticSeverity.ERROR -> NesDiagnosticSeverity.Error
+    V1NesDiagnosticSeverity.WARNING -> NesDiagnosticSeverity.Warning
+    V1NesDiagnosticSeverity.INFORMATION -> NesDiagnosticSeverity.Information
+    V1NesDiagnosticSeverity.HINT -> NesDiagnosticSeverity.Hint
+}
+
+/**
+ * Converts this v2 suggestion to its v1 equivalent.
+ *
+ * The v2 `suggestionId` field maps to v1's `id`, and an absent `isRegex` maps to
+ * v1's `false` default.
+ *
+ * @throws ProtocolConversionException if this is an [NesSuggestion.Unknown] suggestion,
+ * which cannot be represented in v1 without data loss
+ */
+@UnstableApi
+public fun NesSuggestion.toV1(): V1NesSuggestion = when (this) {
+    is NesSuggestion.Edit -> V1NesSuggestion.Edit(
+        id = suggestionId,
+        uri = uri,
+        edits = edits,
+        cursorPosition = cursorPosition,
+    )
+    is NesSuggestion.Jump -> V1NesSuggestion.Jump(
+        id = suggestionId,
+        uri = uri,
+        position = position,
+    )
+    is NesSuggestion.Rename -> V1NesSuggestion.Rename(
+        id = suggestionId,
+        uri = uri,
+        position = position,
+        newName = newName,
+    )
+    is NesSuggestion.SearchAndReplace -> V1NesSuggestion.SearchAndReplace(
+        id = suggestionId,
+        uri = uri,
+        search = search,
+        replace = replace,
+        isRegex = isRegex ?: false,
+    )
+    is NesSuggestion.Unknown -> throw unknownV2EnumVariant("NesSuggestion", kind)
+}
+
+/**
+ * Converts this v1 suggestion to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation. The v1 `id`
+ * field maps to v2's `suggestionId`.
+ */
+@UnstableApi
+public fun V1NesSuggestion.toV2(): NesSuggestion = when (this) {
+    is V1NesSuggestion.Edit -> NesSuggestion.Edit(
+        suggestionId = id,
+        uri = uri,
+        edits = edits,
+        cursorPosition = cursorPosition,
+    )
+    is V1NesSuggestion.Jump -> NesSuggestion.Jump(
+        suggestionId = id,
+        uri = uri,
+        position = position,
+    )
+    is V1NesSuggestion.Rename -> NesSuggestion.Rename(
+        suggestionId = id,
+        uri = uri,
+        position = position,
+        newName = newName,
+    )
+    is V1NesSuggestion.SearchAndReplace -> NesSuggestion.SearchAndReplace(
+        suggestionId = id,
+        uri = uri,
+        search = search,
+        replace = replace,
+        isRegex = isRegex,
+    )
+}

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/PlanConversions.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/PlanConversions.kt
@@ -1,0 +1,200 @@
+@file:Suppress("unused")
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2.conversion
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.PlanEntry as V1PlanEntry
+import com.agentclientprotocol.model.PlanEntryPriority as V1PlanEntryPriority
+import com.agentclientprotocol.model.PlanEntryStatus as V1PlanEntryStatus
+import com.agentclientprotocol.model.PlanVariant as V1PlanVariant
+import com.agentclientprotocol.model.SessionUpdate as V1SessionUpdate
+import com.agentclientprotocol.model.v2.PlanEntry
+import com.agentclientprotocol.model.v2.PlanEntryPriority
+import com.agentclientprotocol.model.v2.PlanEntryStatus
+import com.agentclientprotocol.model.v2.PlanId
+import com.agentclientprotocol.model.v2.PlanRemoved
+import com.agentclientprotocol.model.v2.PlanUpdate
+import com.agentclientprotocol.model.v2.PlanUpdateContent
+
+/**
+ * The plan ID v1 plans are given when converted to v2.
+ *
+ * v1 sessions had a single implicit plan carrying no identifier, so one is synthesized.
+ * Mirrors Rust's `LEGACY_V1_PLAN_ID`.
+ */
+@UnstableApi
+public val LEGACY_V1_PLAN_ID: PlanId = PlanId("main")
+
+/**
+ * Converts this v2 priority to its v1 equivalent.
+ *
+ * @throws ProtocolConversionException if this is an [PlanEntryPriority.Unknown] value,
+ * which cannot be represented in v1 without data loss
+ */
+@UnstableApi
+public fun PlanEntryPriority.toV1(): V1PlanEntryPriority = when (this) {
+    PlanEntryPriority.High -> V1PlanEntryPriority.HIGH
+    PlanEntryPriority.Medium -> V1PlanEntryPriority.MEDIUM
+    PlanEntryPriority.Low -> V1PlanEntryPriority.LOW
+    is PlanEntryPriority.Unknown -> throw unknownV2EnumVariant("PlanEntryPriority", value)
+}
+
+/**
+ * Converts this v1 priority to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1PlanEntryPriority.toV2(): PlanEntryPriority = when (this) {
+    V1PlanEntryPriority.HIGH -> PlanEntryPriority.High
+    V1PlanEntryPriority.MEDIUM -> PlanEntryPriority.Medium
+    V1PlanEntryPriority.LOW -> PlanEntryPriority.Low
+}
+
+/**
+ * Converts this v2 status to its v1 equivalent.
+ *
+ * @throws ProtocolConversionException if this is an [PlanEntryStatus.Unknown] value,
+ * which cannot be represented in v1 without data loss
+ */
+@UnstableApi
+public fun PlanEntryStatus.toV1(): V1PlanEntryStatus = when (this) {
+    PlanEntryStatus.Pending -> V1PlanEntryStatus.PENDING
+    PlanEntryStatus.InProgress -> V1PlanEntryStatus.IN_PROGRESS
+    PlanEntryStatus.Completed -> V1PlanEntryStatus.COMPLETED
+    is PlanEntryStatus.Unknown -> throw unknownV2EnumVariant("PlanEntryStatus", value)
+}
+
+/**
+ * Converts this v1 status to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1PlanEntryStatus.toV2(): PlanEntryStatus = when (this) {
+    V1PlanEntryStatus.PENDING -> PlanEntryStatus.Pending
+    V1PlanEntryStatus.IN_PROGRESS -> PlanEntryStatus.InProgress
+    V1PlanEntryStatus.COMPLETED -> PlanEntryStatus.Completed
+}
+
+/**
+ * Converts this v2 plan entry to its v1 equivalent.
+ *
+ * @throws ProtocolConversionException if [priority] or [status] is an `Unknown` value,
+ * which cannot be represented in v1 without data loss
+ */
+@UnstableApi
+public fun PlanEntry.toV1(): V1PlanEntry = V1PlanEntry(
+    content = content,
+    priority = priority.toV1(),
+    status = status.toV1(),
+    _meta = _meta,
+)
+
+/**
+ * Converts this v1 plan entry to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1PlanEntry.toV2(): PlanEntry = PlanEntry(
+    content = content,
+    priority = priority.toV2(),
+    status = status.toV2(),
+    _meta = _meta,
+)
+
+/**
+ * Converts this v2 plan update to the v1 session update that carries it.
+ *
+ * v1 has two plan updates and no feature flags, so the target is chosen by content type:
+ * [PlanUpdateContent.Items] becomes v1's `plan` update (which has no plan ID — the ID is
+ * dropped), while the file and markdown forms become v1's `plan_update`, whose
+ * [V1PlanVariant] keeps the ID.
+ *
+ * @throws ProtocolConversionException if the content is a [PlanUpdateContent.Unknown]
+ * value, or if an entry's priority or status is `Unknown`
+ */
+@UnstableApi
+public fun PlanUpdate.toV1(): V1SessionUpdate = when (val plan = plan) {
+    is PlanUpdateContent.Items -> V1SessionUpdate.PlanUpdate(
+        entries = plan.entries.map { it.toV1() },
+        _meta = _meta ?: plan._meta,
+    )
+
+    is PlanUpdateContent.File -> V1SessionUpdate.PlanUpdateV2(
+        plan = V1PlanVariant.File(id = plan.planId.value, uri = plan.uri, _meta = plan._meta),
+        _meta = _meta,
+    )
+
+    is PlanUpdateContent.Markdown -> V1SessionUpdate.PlanUpdateV2(
+        plan = V1PlanVariant.Markdown(id = plan.planId.value, content = plan.content, _meta = plan._meta),
+        _meta = _meta,
+    )
+
+    is PlanUpdateContent.Unknown -> throw unknownV2EnumVariant("PlanUpdateContent", plan.type)
+}
+
+/**
+ * Converts this v1 `plan` update to its v2 equivalent.
+ *
+ * v1 plans carry no identifier, so the entries are attributed to [LEGACY_V1_PLAN_ID].
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1SessionUpdate.PlanUpdate.toV2(): PlanUpdate = PlanUpdate(
+    plan = PlanUpdateContent.Items(
+        planId = LEGACY_V1_PLAN_ID,
+        entries = entries.map { it.toV2() },
+    ),
+    _meta = _meta,
+)
+
+/**
+ * Converts this v1 `plan_update` to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1SessionUpdate.PlanUpdateV2.toV2(): PlanUpdate = PlanUpdate(
+    plan = when (val plan = plan) {
+        is V1PlanVariant.Items -> PlanUpdateContent.Items(
+            planId = PlanId(plan.id),
+            entries = plan.entries.map { it.toV2() },
+            _meta = plan._meta,
+        )
+
+        is V1PlanVariant.File -> PlanUpdateContent.File(
+            planId = PlanId(plan.id),
+            uri = plan.uri,
+            _meta = plan._meta,
+        )
+
+        is V1PlanVariant.Markdown -> PlanUpdateContent.Markdown(
+            planId = PlanId(plan.id),
+            content = plan.content,
+            _meta = plan._meta,
+        )
+    },
+    _meta = _meta,
+)
+
+/**
+ * Converts this v2 plan removal to its v1 equivalent.
+ *
+ * This conversion is total: every v2 value has a v1 representation.
+ */
+@UnstableApi
+public fun PlanRemoved.toV1(): V1SessionUpdate.PlanRemoved =
+    V1SessionUpdate.PlanRemoved(id = planId.value, _meta = _meta)
+
+/**
+ * Converts this v1 plan removal to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1SessionUpdate.PlanRemoved.toV2(): PlanRemoved =
+    PlanRemoved(planId = PlanId(id), _meta = _meta)

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/ProtocolConversionException.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/ProtocolConversionException.kt
@@ -1,0 +1,31 @@
+package com.agentclientprotocol.model.v2.conversion
+
+import com.agentclientprotocol.annotations.UnstableApi
+
+/**
+ * Thrown when converting between the v1 and v2 protocol type namespaces fails because a
+ * value cannot be represented in the target version without data loss.
+ *
+ * For example, a v2 open-enum [Unknown][com.agentclientprotocol.model.v2.ToolCallStatus.Unknown]
+ * value has no v1 equivalent, so v2 → v1 conversion fails instead of silently dropping it.
+ */
+@UnstableApi
+public class ProtocolConversionException(message: String) : RuntimeException(message)
+
+/**
+ * Creates the error for a v2 open-enum value that has no v1 representation.
+ *
+ * The message format matches the reference Rust implementation.
+ */
+@UnstableApi
+internal fun unknownV2EnumVariant(typeName: String, value: String): ProtocolConversionException =
+    ProtocolConversionException("v2 $typeName variant `$value` cannot be represented in v1")
+
+/**
+ * Creates the error for a v1 value whose variant was removed in v2.
+ *
+ * The message format matches the reference Rust implementation.
+ */
+@UnstableApi
+internal fun removedV1EnumVariant(typeName: String, value: String): ProtocolConversionException =
+    ProtocolConversionException("v1 $typeName variant `$value` cannot be represented in v2")

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/RequestsConversions.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/RequestsConversions.kt
@@ -1,0 +1,231 @@
+@file:Suppress("unused")
+
+package com.agentclientprotocol.model.v2.conversion
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.EnvVariable
+import com.agentclientprotocol.model.AuthMethod as V1AuthMethod
+import com.agentclientprotocol.model.LlmProtocol as V1LlmProtocol
+import com.agentclientprotocol.model.McpServer as V1McpServer
+import com.agentclientprotocol.model.PermissionOptionKind as V1PermissionOptionKind
+import com.agentclientprotocol.model.RequestPermissionOutcome as V1RequestPermissionOutcome
+import com.agentclientprotocol.model.StopReason as V1StopReason
+import com.agentclientprotocol.model.v2.AuthMethod
+import com.agentclientprotocol.model.v2.LlmProtocol
+import com.agentclientprotocol.model.v2.McpServer
+import com.agentclientprotocol.model.v2.PermissionOptionKind
+import com.agentclientprotocol.model.v2.RequestPermissionOutcome
+import com.agentclientprotocol.model.v2.StopReason
+
+/**
+ * Converts this v2 stop reason to its v1 equivalent.
+ *
+ * @throws ProtocolConversionException if this is an [StopReason.Unknown] value,
+ * which cannot be represented in v1 without data loss
+ */
+@UnstableApi
+public fun StopReason.toV1(): V1StopReason = when (this) {
+    StopReason.EndTurn -> V1StopReason.END_TURN
+    StopReason.MaxTokens -> V1StopReason.MAX_TOKENS
+    StopReason.MaxTurnRequests -> V1StopReason.MAX_TURN_REQUESTS
+    StopReason.Refusal -> V1StopReason.REFUSAL
+    StopReason.Cancelled -> V1StopReason.CANCELLED
+    is StopReason.Unknown -> throw unknownV2EnumVariant("StopReason", value)
+}
+
+/**
+ * Converts this v1 stop reason to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1StopReason.toV2(): StopReason = when (this) {
+    V1StopReason.END_TURN -> StopReason.EndTurn
+    V1StopReason.MAX_TOKENS -> StopReason.MaxTokens
+    V1StopReason.MAX_TURN_REQUESTS -> StopReason.MaxTurnRequests
+    V1StopReason.REFUSAL -> StopReason.Refusal
+    V1StopReason.CANCELLED -> StopReason.Cancelled
+}
+
+/**
+ * Converts this v2 kind to its v1 equivalent.
+ *
+ * @throws ProtocolConversionException if this is an [PermissionOptionKind.Unknown] value,
+ * which cannot be represented in v1 without data loss
+ */
+@UnstableApi
+public fun PermissionOptionKind.toV1(): V1PermissionOptionKind = when (this) {
+    PermissionOptionKind.AllowOnce -> V1PermissionOptionKind.ALLOW_ONCE
+    PermissionOptionKind.AllowAlways -> V1PermissionOptionKind.ALLOW_ALWAYS
+    PermissionOptionKind.RejectOnce -> V1PermissionOptionKind.REJECT_ONCE
+    PermissionOptionKind.RejectAlways -> V1PermissionOptionKind.REJECT_ALWAYS
+    is PermissionOptionKind.Unknown -> throw unknownV2EnumVariant("PermissionOptionKind", value)
+}
+
+/**
+ * Converts this v1 kind to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1PermissionOptionKind.toV2(): PermissionOptionKind = when (this) {
+    V1PermissionOptionKind.ALLOW_ONCE -> PermissionOptionKind.AllowOnce
+    V1PermissionOptionKind.ALLOW_ALWAYS -> PermissionOptionKind.AllowAlways
+    V1PermissionOptionKind.REJECT_ONCE -> PermissionOptionKind.RejectOnce
+    V1PermissionOptionKind.REJECT_ALWAYS -> PermissionOptionKind.RejectAlways
+}
+
+/**
+ * Converts this v2 MCP server configuration to its v1 equivalent.
+ *
+ * The `_meta` field is dropped: the v1 Kotlin model does not carry metadata on
+ * MCP server configurations.
+ *
+ * @throws ProtocolConversionException if this is an [McpServer.Unknown] transport,
+ * which cannot be represented in v1 without data loss
+ */
+@UnstableApi
+public fun McpServer.toV1(): V1McpServer = when (this) {
+    is McpServer.Http -> V1McpServer.Http(name = name, url = url, headers = headers)
+    is McpServer.Stdio -> V1McpServer.Stdio(name = name, command = command, args = args, env = env)
+    is McpServer.Unknown -> throw unknownV2EnumVariant("McpServer", type)
+}
+
+/**
+ * Converts this v1 MCP server configuration to its v2 equivalent.
+ *
+ * @throws ProtocolConversionException if this is an [V1McpServer.Sse] configuration —
+ * the SSE transport was removed in v2
+ */
+@UnstableApi
+public fun V1McpServer.toV2(): McpServer = when (this) {
+    is V1McpServer.Http -> McpServer.Http(name = name, url = url, headers = headers)
+    is V1McpServer.Sse -> throw removedV1EnumVariant("McpServer", "sse")
+    is V1McpServer.Stdio -> McpServer.Stdio(name = name, command = command, args = args, env = env)
+}
+
+/**
+ * Converts this v2 authentication method to its v1 equivalent.
+ *
+ * The v2 `methodId` field maps to v1's `id`. For [AuthMethod.Terminal], v2's structured
+ * `env` list flattens to v1's string map (per-variable `_meta` is dropped), and empty
+ * `args`/`env` map to v1's absent values.
+ *
+ * @throws ProtocolConversionException if this is an [AuthMethod.Unknown] method — the
+ * payload schema of an unknown method type is undefined and the v1 and v2 wire shapes
+ * differ (`id` vs `methodId`), so a faithful translation is not possible
+ */
+@UnstableApi
+public fun AuthMethod.toV1(): V1AuthMethod = when (this) {
+    is AuthMethod.Agent -> V1AuthMethod.AgentAuth(
+        id = methodId,
+        name = name,
+        description = description,
+        _meta = _meta,
+    )
+    is AuthMethod.EnvVar -> V1AuthMethod.EnvVarAuth(
+        id = methodId,
+        name = name,
+        description = description,
+        vars = vars,
+        link = link,
+        _meta = _meta,
+    )
+    is AuthMethod.Terminal -> V1AuthMethod.TerminalAuth(
+        id = methodId,
+        name = name,
+        description = description,
+        args = args.takeIf { it.isNotEmpty() },
+        env = env.takeIf { it.isNotEmpty() }?.associate { it.name to it.value },
+        _meta = _meta,
+    )
+    is AuthMethod.Unknown -> throw unknownV2EnumVariant("AuthMethod", type)
+}
+
+/**
+ * Converts this v1 authentication method to its v2 equivalent.
+ *
+ * The v1 `id` field maps to v2's `methodId`.
+ *
+ * @throws ProtocolConversionException if this is a [V1AuthMethod.UnknownAuthMethod] — the
+ * payload schema of an unknown method type is undefined and the v1 and v2 wire shapes
+ * differ (`id` vs `methodId`), so a faithful translation is not possible
+ */
+@UnstableApi
+public fun V1AuthMethod.toV2(): AuthMethod = when (this) {
+    is V1AuthMethod.AgentAuth -> AuthMethod.Agent(
+        methodId = id,
+        name = name,
+        description = description,
+        _meta = _meta,
+    )
+    is V1AuthMethod.EnvVarAuth -> AuthMethod.EnvVar(
+        methodId = id,
+        name = name,
+        description = description,
+        vars = vars,
+        link = link,
+        _meta = _meta,
+    )
+    is V1AuthMethod.TerminalAuth -> AuthMethod.Terminal(
+        methodId = id,
+        name = name,
+        description = description,
+        args = args.orEmpty(),
+        env = env.orEmpty().map { (name, value) -> EnvVariable(name, value) },
+        _meta = _meta,
+    )
+    is V1AuthMethod.UnknownAuthMethod -> throw removedV1EnumVariant("AuthMethod", type)
+}
+
+/**
+ * Converts this v2 permission outcome to its v1 equivalent.
+ *
+ * The `_meta` field of [RequestPermissionOutcome.Selected] is dropped: the v1 Kotlin
+ * model does not carry metadata on the selected outcome.
+ *
+ * @throws ProtocolConversionException if this is an [RequestPermissionOutcome.Unknown]
+ * outcome, which cannot be represented in v1 without data loss
+ */
+@UnstableApi
+public fun RequestPermissionOutcome.toV1(): V1RequestPermissionOutcome = when (this) {
+    is RequestPermissionOutcome.Cancelled -> V1RequestPermissionOutcome.Cancelled
+    is RequestPermissionOutcome.Selected -> V1RequestPermissionOutcome.Selected(optionId = optionId)
+    is RequestPermissionOutcome.Unknown -> throw unknownV2EnumVariant("RequestPermissionOutcome", outcome)
+}
+
+/**
+ * Converts this v1 permission outcome to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1RequestPermissionOutcome.toV2(): RequestPermissionOutcome = when (this) {
+    is V1RequestPermissionOutcome.Cancelled -> RequestPermissionOutcome.Cancelled
+    is V1RequestPermissionOutcome.Selected -> RequestPermissionOutcome.Selected(optionId = optionId)
+}
+
+/**
+ * Converts this v2 protocol to its v1 equivalent.
+ *
+ * This conversion is total: the v1 type is an open string wrapper, so every v2 value —
+ * including [LlmProtocol.Unknown] — has a v1 representation.
+ */
+@UnstableApi
+public fun LlmProtocol.toV1(): V1LlmProtocol = V1LlmProtocol(value)
+
+/**
+ * Converts this v1 protocol to its v2 equivalent.
+ *
+ * This conversion is total: well-known identifiers map to their v2 variants and any
+ * other string maps to [LlmProtocol.Unknown].
+ */
+@UnstableApi
+public fun V1LlmProtocol.toV2(): LlmProtocol = when (this) {
+    V1LlmProtocol.ANTHROPIC -> LlmProtocol.Anthropic
+    V1LlmProtocol.OPENAI -> LlmProtocol.OpenAi
+    V1LlmProtocol.AZURE -> LlmProtocol.Azure
+    V1LlmProtocol.VERTEX -> LlmProtocol.Vertex
+    V1LlmProtocol.BEDROCK -> LlmProtocol.Bedrock
+    else -> LlmProtocol.Unknown(value)
+}

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/SessionConfigConversions.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/SessionConfigConversions.kt
@@ -1,0 +1,176 @@
+@file:Suppress("unused")
+
+package com.agentclientprotocol.model.v2.conversion
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.SessionConfigValueId
+import com.agentclientprotocol.model.SessionConfigOption as V1SessionConfigOption
+import com.agentclientprotocol.model.SessionConfigOptionCategory as V1SessionConfigOptionCategory
+import com.agentclientprotocol.model.SessionConfigOptionValue as V1SessionConfigOptionValue
+import com.agentclientprotocol.model.SessionConfigSelectGroup as V1SessionConfigSelectGroup
+import com.agentclientprotocol.model.SessionConfigSelectOptions as V1SessionConfigSelectOptions
+import com.agentclientprotocol.model.v2.SessionConfigKind
+import com.agentclientprotocol.model.v2.SessionConfigOption
+import com.agentclientprotocol.model.v2.SessionConfigOptionCategory
+import com.agentclientprotocol.model.v2.SessionConfigOptionValue
+import com.agentclientprotocol.model.v2.SessionConfigSelectGroup
+import com.agentclientprotocol.model.v2.SessionConfigSelectOptions
+
+/**
+ * Converts this v2 category to its v1 equivalent.
+ *
+ * This conversion is total: the v1 type is an open string wrapper, so every v2 value —
+ * including [SessionConfigOptionCategory.Unknown] — has a v1 representation.
+ */
+@UnstableApi
+public fun SessionConfigOptionCategory.toV1(): V1SessionConfigOptionCategory =
+    V1SessionConfigOptionCategory(value)
+
+/**
+ * Converts this v1 category to its v2 equivalent.
+ *
+ * This conversion is total: well-known categories map to their v2 variants and any
+ * other string maps to [SessionConfigOptionCategory.Unknown].
+ */
+@UnstableApi
+public fun V1SessionConfigOptionCategory.toV2(): SessionConfigOptionCategory = when (value) {
+    SessionConfigOptionCategory.Mode.value -> SessionConfigOptionCategory.Mode
+    SessionConfigOptionCategory.Model.value -> SessionConfigOptionCategory.Model
+    SessionConfigOptionCategory.ModelConfig.value -> SessionConfigOptionCategory.ModelConfig
+    SessionConfigOptionCategory.ThoughtLevel.value -> SessionConfigOptionCategory.ThoughtLevel
+    else -> SessionConfigOptionCategory.Unknown(value)
+}
+
+/**
+ * Converts this v2 select group to its v1 equivalent.
+ *
+ * The v2 `groupId` field maps to v1's `group`.
+ */
+@UnstableApi
+public fun SessionConfigSelectGroup.toV1(): V1SessionConfigSelectGroup = V1SessionConfigSelectGroup(
+    group = groupId,
+    name = name,
+    options = options,
+    _meta = _meta,
+)
+
+/**
+ * Converts this v1 select group to its v2 equivalent.
+ *
+ * The v1 `group` field maps to v2's `groupId`. v2 requires a group name, so an absent
+ * v1 name maps to an empty string.
+ */
+@UnstableApi
+public fun V1SessionConfigSelectGroup.toV2(): SessionConfigSelectGroup = SessionConfigSelectGroup(
+    groupId = group,
+    name = name.orEmpty(),
+    options = options,
+    _meta = _meta,
+)
+
+/**
+ * Converts these v2 select options to their v1 equivalent.
+ *
+ * This conversion is total: [SessionConfigSelectOptions.Ungrouped] maps to v1's `Flat`.
+ */
+@UnstableApi
+public fun SessionConfigSelectOptions.toV1(): V1SessionConfigSelectOptions = when (this) {
+    is SessionConfigSelectOptions.Ungrouped -> V1SessionConfigSelectOptions.Flat(options)
+    is SessionConfigSelectOptions.Grouped -> V1SessionConfigSelectOptions.Grouped(groups.map { it.toV1() })
+}
+
+/**
+ * Converts these v1 select options to their v2 equivalent.
+ *
+ * This conversion is total: v1's `Flat` maps to [SessionConfigSelectOptions.Ungrouped].
+ */
+@UnstableApi
+public fun V1SessionConfigSelectOptions.toV2(): SessionConfigSelectOptions = when (this) {
+    is V1SessionConfigSelectOptions.Flat -> SessionConfigSelectOptions.Ungrouped(options)
+    is V1SessionConfigSelectOptions.Grouped -> SessionConfigSelectOptions.Grouped(groups.map { it.toV2() })
+}
+
+/**
+ * Converts this v2 configuration option to its v1 equivalent.
+ *
+ * The v2 `configId` field maps to v1's `id`.
+ *
+ * @throws ProtocolConversionException if [SessionConfigOption.kind] is an
+ * [SessionConfigKind.Unknown] payload, which cannot be represented in v1 without
+ * data loss
+ */
+@UnstableApi
+public fun SessionConfigOption.toV1(): V1SessionConfigOption = when (val kind = kind) {
+    is SessionConfigKind.Select -> V1SessionConfigOption.Select(
+        id = configId,
+        name = name,
+        description = description,
+        category = category?.toV1(),
+        currentValue = kind.currentValue,
+        options = kind.options.toV1(),
+        _meta = _meta,
+    )
+    is SessionConfigKind.Boolean -> V1SessionConfigOption.BooleanOption(
+        id = configId,
+        name = name,
+        description = description,
+        category = category?.toV1(),
+        currentValue = kind.currentValue,
+        _meta = _meta,
+    )
+    is SessionConfigKind.Unknown -> throw unknownV2EnumVariant("SessionConfigKind", kind.type)
+}
+
+/**
+ * Converts this v1 configuration option to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation. The v1 `id`
+ * field maps to v2's `configId`.
+ */
+@UnstableApi
+public fun V1SessionConfigOption.toV2(): SessionConfigOption = when (this) {
+    is V1SessionConfigOption.Select -> SessionConfigOption(
+        configId = id,
+        name = name,
+        description = description,
+        category = category?.toV2(),
+        kind = SessionConfigKind.Select(currentValue = currentValue, options = options.toV2()),
+        _meta = _meta,
+    )
+    is V1SessionConfigOption.BooleanOption -> SessionConfigOption(
+        configId = id,
+        name = name,
+        description = description,
+        category = category?.toV2(),
+        kind = SessionConfigKind.Boolean(currentValue = currentValue),
+        _meta = _meta,
+    )
+}
+
+/**
+ * Converts this v2 option value to its v1 equivalent.
+ *
+ * @throws ProtocolConversionException if this is an [SessionConfigOptionValue.Unknown]
+ * value, which cannot be represented in v1 without data loss
+ */
+@UnstableApi
+public fun SessionConfigOptionValue.toV1(): V1SessionConfigOptionValue = when (this) {
+    is SessionConfigOptionValue.Id -> V1SessionConfigOptionValue.StringValue(value.value)
+    is SessionConfigOptionValue.Boolean -> V1SessionConfigOptionValue.BoolValue(value)
+    is SessionConfigOptionValue.Unknown -> throw unknownV2EnumVariant("SessionConfigOptionValue", type)
+}
+
+/**
+ * Converts this v1 option value to its v2 equivalent.
+ *
+ * @throws ProtocolConversionException if this is a
+ * [V1SessionConfigOptionValue.UnknownValue] — its raw untagged payload has no faithful
+ * representation in v2's tagged value objects
+ */
+@UnstableApi
+public fun V1SessionConfigOptionValue.toV2(): SessionConfigOptionValue = when (this) {
+    is V1SessionConfigOptionValue.StringValue -> SessionConfigOptionValue.Id(SessionConfigValueId(value))
+    is V1SessionConfigOptionValue.BoolValue -> SessionConfigOptionValue.Boolean(value)
+    is V1SessionConfigOptionValue.UnknownValue ->
+        throw removedV1EnumVariant("SessionConfigOptionValue", "UnknownValue")
+}

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/SessionUpdateConversions.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/SessionUpdateConversions.kt
@@ -1,0 +1,374 @@
+@file:Suppress("unused")
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2.conversion
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.AvailableCommand as V1AvailableCommand
+import com.agentclientprotocol.model.AvailableCommandInput as V1AvailableCommandInput
+import com.agentclientprotocol.model.SessionUpdate as V1SessionUpdate
+import com.agentclientprotocol.model.v2.AgentMessage
+import com.agentclientprotocol.model.v2.AgentThought
+import com.agentclientprotocol.model.v2.AvailableCommand
+import com.agentclientprotocol.model.v2.AvailableCommandInput
+import com.agentclientprotocol.model.v2.AvailableCommandsUpdate
+import com.agentclientprotocol.model.v2.ConfigOptionUpdate
+import com.agentclientprotocol.model.v2.ContentBlock
+import com.agentclientprotocol.model.v2.ContentChunk
+import com.agentclientprotocol.model.v2.MaybeUndefined
+import com.agentclientprotocol.model.v2.SessionInfoUpdate
+import com.agentclientprotocol.model.v2.SessionUpdate
+import com.agentclientprotocol.model.v2.UsageUpdate
+import com.agentclientprotocol.model.v2.UserMessage
+import com.agentclientprotocol.model.MessageId
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Converts this v2 command input to its v1 equivalent.
+ *
+ * The v2 `text` discriminator maps to v1's `unstructured`.
+ *
+ * @throws ProtocolConversionException if this is an [AvailableCommandInput.Unknown] value,
+ * which cannot be represented in v1 without data loss
+ */
+@UnstableApi
+public fun AvailableCommandInput.toV1(): V1AvailableCommandInput = when (this) {
+    is AvailableCommandInput.Text -> V1AvailableCommandInput.Unstructured(hint = hint, _meta = _meta)
+    is AvailableCommandInput.Unknown -> throw unknownV2EnumVariant("AvailableCommandInput", type)
+}
+
+/**
+ * Converts this v1 command input to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1AvailableCommandInput.toV2(): AvailableCommandInput = when (this) {
+    is V1AvailableCommandInput.Unstructured -> AvailableCommandInput.Text(hint = hint, _meta = _meta)
+}
+
+/**
+ * Converts this v2 command to its v1 equivalent.
+ *
+ * @throws ProtocolConversionException if [input] is an [AvailableCommandInput.Unknown] value
+ */
+@UnstableApi
+public fun AvailableCommand.toV1(): V1AvailableCommand = V1AvailableCommand(
+    name = name,
+    description = description,
+    input = input?.toV1(),
+    _meta = _meta,
+)
+
+/**
+ * Converts this v1 command to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1AvailableCommand.toV2(): AvailableCommand = AvailableCommand(
+    name = name,
+    description = description,
+    input = input?.toV2(),
+    _meta = _meta,
+)
+
+/**
+ * Converts this v2 commands update to the v1 session update that carries it.
+ *
+ * Commands whose own conversion fails are skipped, mirroring the Rust conversion.
+ *
+ * @throws ProtocolConversionException if [AvailableCommandsUpdate._meta] is set — v1's
+ * commands update has no metadata field, so it would be silently dropped
+ */
+@UnstableApi
+public fun AvailableCommandsUpdate.toV1(): V1SessionUpdate.AvailableCommandsUpdate {
+    if (_meta != null) {
+        throw ProtocolConversionException(
+            "v2 AvailableCommandsUpdate with _meta cannot be represented in v1, " +
+                "whose available_commands_update has no _meta field"
+        )
+    }
+    return V1SessionUpdate.AvailableCommandsUpdate(
+        availableCommands = availableCommands.mapNotNull { command ->
+            try {
+                command.toV1()
+            } catch (_: ProtocolConversionException) {
+                null
+            }
+        },
+    )
+}
+
+/**
+ * Converts this v1 commands update to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1SessionUpdate.AvailableCommandsUpdate.toV2(): AvailableCommandsUpdate =
+    AvailableCommandsUpdate(availableCommands = availableCommands.map { it.toV2() })
+
+/**
+ * Converts this v2 config options update to the v1 session update that carries it.
+ *
+ * Options whose own conversion fails are skipped, mirroring the Rust conversion.
+ */
+@UnstableApi
+public fun ConfigOptionUpdate.toV1(): V1SessionUpdate.ConfigOptionUpdate =
+    V1SessionUpdate.ConfigOptionUpdate(
+        configOptions = configOptions.mapNotNull { option ->
+            try {
+                option.toV1()
+            } catch (_: ProtocolConversionException) {
+                null
+            }
+        },
+        _meta = _meta,
+    )
+
+/**
+ * Converts this v1 config options update to its v2 equivalent.
+ *
+ * Options whose own conversion fails are skipped, mirroring the Rust conversion.
+ */
+@UnstableApi
+public fun V1SessionUpdate.ConfigOptionUpdate.toV2(): ConfigOptionUpdate = ConfigOptionUpdate(
+    configOptions = configOptions.mapNotNull { option ->
+        try {
+            option.toV2()
+        } catch (_: ProtocolConversionException) {
+            null
+        }
+    },
+    _meta = _meta,
+)
+
+/**
+ * Converts this v2 session info update to the v1 session update that carries it.
+ *
+ * v1 has no patch semantics, so both "no update" and an explicit clear become an unset
+ * field.
+ *
+ * @throws ProtocolConversionException if [SessionInfoUpdate._meta] is an explicit clear,
+ * which v1 cannot express
+ */
+@UnstableApi
+public fun SessionInfoUpdate.toV1(): V1SessionUpdate.SessionInfoUpdate =
+    V1SessionUpdate.SessionInfoUpdate(
+        title = title.valueOrNull(),
+        updatedAt = updatedAt.valueOrNull(),
+        _meta = _meta.metaValueOrThrow("SessionInfoUpdate"),
+    )
+
+/**
+ * Converts this v1 session info update to its v2 equivalent.
+ *
+ * An unset v1 field becomes "no update" rather than an explicit clear.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1SessionUpdate.SessionInfoUpdate.toV2(): SessionInfoUpdate = SessionInfoUpdate(
+    title = title.toV2MaybeUndefined(),
+    updatedAt = updatedAt.toV2MaybeUndefined(),
+    _meta = _meta.toV2MaybeUndefined(),
+)
+
+/**
+ * Converts this v2 usage update to the v1 session update that carries it.
+ *
+ * This conversion is total: every v2 value has a v1 representation.
+ */
+@UnstableApi
+public fun UsageUpdate.toV1(): V1SessionUpdate.UsageUpdate =
+    V1SessionUpdate.UsageUpdate(used = used, size = size, cost = cost, _meta = _meta)
+
+/**
+ * Converts this v1 usage update to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1SessionUpdate.UsageUpdate.toV2(): UsageUpdate =
+    UsageUpdate(used = used, size = size, cost = cost, _meta = _meta)
+
+/**
+ * The metadata value of a patch state, rejecting an explicit clear.
+ *
+ * v1 cannot distinguish "leave metadata alone" from "clear it", so an explicit clear has no
+ * faithful v1 form.
+ */
+private fun MaybeUndefined<JsonElement>.metaValueOrThrow(context: String): JsonElement? =
+    when (this) {
+        is MaybeUndefined.Value -> value
+        MaybeUndefined.Null -> throw ProtocolConversionException(
+            "v2 $context with null _meta cannot be represented in v1"
+        )
+
+        MaybeUndefined.Undefined -> null
+    }
+
+/**
+ * Converts this v2 session update to the v1 session updates that represent it.
+ *
+ * The result is a **list** because one v2 update can require several v1 updates: v1 has no
+ * whole-message upsert, so [SessionUpdate.UserMessage], [SessionUpdate.AgentMessage], and
+ * [SessionUpdate.AgentThought] expand into one v1 chunk per content block. Every other
+ * variant yields exactly one update.
+ *
+ * @throws ProtocolConversionException if this update has no v1 representation:
+ * [SessionUpdate.StateUpdate] (v1 reports completion in the `session/prompt` response),
+ * [SessionUpdate.ToolCallContentChunk] (v1 content updates replace rather than append),
+ * [SessionUpdate.Unknown], a message upsert whose content is absent, cleared, or empty, or
+ * a nested payload that cannot itself be converted
+ */
+@UnstableApi
+public fun SessionUpdate.toV1(): List<V1SessionUpdate> = when (this) {
+    is SessionUpdate.UserMessageChunk ->
+        listOf(chunk.toV1ContentChunk(V1SessionUpdate::UserMessageChunk))
+
+    is SessionUpdate.AgentMessageChunk ->
+        listOf(chunk.toV1ContentChunk(V1SessionUpdate::AgentMessageChunk))
+
+    is SessionUpdate.AgentThoughtChunk ->
+        listOf(chunk.toV1ContentChunk(V1SessionUpdate::AgentThoughtChunk))
+
+    is SessionUpdate.UserMessage -> messageToV1Chunks(
+        variant = "user_message",
+        messageId = message.messageId,
+        content = message.content,
+        meta = message._meta,
+        wrap = V1SessionUpdate::UserMessageChunk,
+    )
+
+    is SessionUpdate.AgentMessage -> messageToV1Chunks(
+        variant = "agent_message",
+        messageId = message.messageId,
+        content = message.content,
+        meta = message._meta,
+        wrap = V1SessionUpdate::AgentMessageChunk,
+    )
+
+    is SessionUpdate.AgentThought -> messageToV1Chunks(
+        variant = "agent_thought",
+        messageId = thought.messageId,
+        content = thought.content,
+        meta = thought._meta,
+        wrap = V1SessionUpdate::AgentThoughtChunk,
+    )
+
+    is SessionUpdate.StateUpdate -> throw ProtocolConversionException(
+        "v2 SessionUpdate variant `state_update` cannot be represented in v1 because v1 " +
+            "reports completion in the session/prompt response"
+    )
+
+    is SessionUpdate.ToolCallContentChunk -> throw ProtocolConversionException(
+        "v2 SessionUpdate variant `tool_call_content_chunk` cannot be represented in v1 " +
+            "because v1 tool-call content updates replace content instead of appending"
+    )
+
+    is SessionUpdate.ToolCallUpdate -> listOf(update.toV1())
+    is SessionUpdate.PlanUpdate -> listOf(update.toV1())
+    is SessionUpdate.PlanRemoved -> listOf(removed.toV1())
+    is SessionUpdate.AvailableCommandsUpdate -> listOf(update.toV1())
+    is SessionUpdate.ConfigOptionUpdate -> listOf(update.toV1())
+    is SessionUpdate.SessionInfoUpdate -> listOf(update.toV1())
+    is SessionUpdate.UsageUpdate -> listOf(update.toV1())
+    is SessionUpdate.Unknown -> throw unknownV2EnumVariant("SessionUpdate", sessionUpdate)
+}
+
+/**
+ * Converts this v1 session update to its v2 equivalent.
+ *
+ * v1's separate `tool_call` and `tool_call_update` both become [SessionUpdate.ToolCallUpdate],
+ * and v1's identifier-less `plan` becomes a plan update for [LEGACY_V1_PLAN_ID].
+ *
+ * An unrecognized v1 update crosses unchanged: both versions preserve one as raw JSON.
+ *
+ * @throws ProtocolConversionException if this is a `current_mode_update`, which v2 removed,
+ * or a message chunk with no `messageId`, which v2 requires
+ */
+@UnstableApi
+public fun V1SessionUpdate.toV2(): SessionUpdate = when (this) {
+    is V1SessionUpdate.UserMessageChunk -> SessionUpdate.UserMessageChunk(
+        toV2ContentChunk("user_message_chunk", content, messageId, _meta),
+    )
+
+    is V1SessionUpdate.AgentMessageChunk -> SessionUpdate.AgentMessageChunk(
+        toV2ContentChunk("agent_message_chunk", content, messageId, _meta),
+    )
+
+    is V1SessionUpdate.AgentThoughtChunk -> SessionUpdate.AgentThoughtChunk(
+        toV2ContentChunk("agent_thought_chunk", content, messageId, _meta),
+    )
+
+    is V1SessionUpdate.ToolCall -> SessionUpdate.ToolCallUpdate(toV2())
+    is V1SessionUpdate.ToolCallUpdate -> SessionUpdate.ToolCallUpdate(toV2())
+    is V1SessionUpdate.PlanUpdate -> SessionUpdate.PlanUpdate(toV2())
+    is V1SessionUpdate.PlanUpdateV2 -> SessionUpdate.PlanUpdate(toV2())
+    is V1SessionUpdate.PlanRemoved -> SessionUpdate.PlanRemoved(toV2())
+    is V1SessionUpdate.AvailableCommandsUpdate -> SessionUpdate.AvailableCommandsUpdate(toV2())
+    is V1SessionUpdate.ConfigOptionUpdate -> SessionUpdate.ConfigOptionUpdate(toV2())
+    is V1SessionUpdate.SessionInfoUpdate -> SessionUpdate.SessionInfoUpdate(toV2())
+    is V1SessionUpdate.UsageUpdate -> SessionUpdate.UsageUpdate(toV2())
+
+    is V1SessionUpdate.CurrentModeUpdate ->
+        throw removedV1EnumVariant("SessionUpdate", "current_mode_update")
+
+    // Both versions keep unrecognized updates as raw JSON, so this crosses losslessly.
+    is V1SessionUpdate.UnknownSessionUpdate ->
+        SessionUpdate.Unknown(sessionUpdate = sessionUpdateType, rawJson = rawJson)
+}
+
+private inline fun ContentChunk.toV1ContentChunk(
+    wrap: (com.agentclientprotocol.model.ContentBlock, MessageId?, JsonElement?) -> V1SessionUpdate,
+): V1SessionUpdate = wrap(content.toV1(), messageId, _meta)
+
+private fun toV2ContentChunk(
+    variant: String,
+    content: com.agentclientprotocol.model.ContentBlock,
+    messageId: MessageId?,
+    meta: JsonElement?,
+): ContentChunk = ContentChunk(
+    messageId = messageId ?: throw ProtocolConversionException(
+        "v1 SessionUpdate variant `$variant` without messageId cannot be represented in v2, " +
+            "whose content chunks require one"
+    ),
+    content = content.toV2(),
+    _meta = meta,
+)
+
+private inline fun messageToV1Chunks(
+    variant: String,
+    messageId: MessageId,
+    content: MaybeUndefined<List<ContentBlock>>,
+    meta: MaybeUndefined<JsonElement>,
+    wrap: (com.agentclientprotocol.model.ContentBlock, MessageId?, JsonElement?) -> V1SessionUpdate,
+): List<V1SessionUpdate> {
+    val blocks = when (content) {
+        is MaybeUndefined.Value -> content.value.ifEmpty {
+            throw ProtocolConversionException(
+                "v2 SessionUpdate variant `$variant` with empty content cannot be represented " +
+                    "in v1 chunks"
+            )
+        }
+
+        MaybeUndefined.Null -> throw ProtocolConversionException(
+            "v2 SessionUpdate variant `$variant` with null content cannot be represented in v1 chunks"
+        )
+
+        MaybeUndefined.Undefined -> throw ProtocolConversionException(
+            "v2 SessionUpdate variant `$variant` without content cannot be represented in v1 chunks"
+        )
+    }
+    val v1Meta = when (meta) {
+        is MaybeUndefined.Value -> meta.value
+        MaybeUndefined.Null -> throw ProtocolConversionException(
+            "v2 SessionUpdate variant `$variant` with null _meta cannot be represented in v1 chunks"
+        )
+
+        MaybeUndefined.Undefined -> null
+    }
+    return blocks.map { block -> wrap(block.toV1(), messageId, v1Meta) }
+}

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/ToolCallConversions.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/ToolCallConversions.kt
@@ -1,0 +1,232 @@
+@file:Suppress("unused")
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2.conversion
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.SessionUpdate as V1SessionUpdate
+import com.agentclientprotocol.model.ToolCallContent as V1ToolCallContent
+import com.agentclientprotocol.model.ToolCallStatus as V1ToolCallStatus
+import com.agentclientprotocol.model.ToolKind as V1ToolKind
+import com.agentclientprotocol.model.v2.MaybeUndefined
+import com.agentclientprotocol.model.v2.ToolCallContent
+import com.agentclientprotocol.model.v2.ToolCallStatus
+import com.agentclientprotocol.model.v2.ToolCallUpdate
+import com.agentclientprotocol.model.v2.ToolKind
+
+/**
+ * Converts this v2 kind to its v1 equivalent.
+ *
+ * @throws ProtocolConversionException if this is an [ToolKind.Unknown] value,
+ * which cannot be represented in v1 without data loss
+ */
+@UnstableApi
+public fun ToolKind.toV1(): V1ToolKind = when (this) {
+    ToolKind.Read -> V1ToolKind.READ
+    ToolKind.Edit -> V1ToolKind.EDIT
+    ToolKind.Delete -> V1ToolKind.DELETE
+    ToolKind.Move -> V1ToolKind.MOVE
+    ToolKind.Search -> V1ToolKind.SEARCH
+    ToolKind.Execute -> V1ToolKind.EXECUTE
+    ToolKind.Think -> V1ToolKind.THINK
+    ToolKind.Fetch -> V1ToolKind.FETCH
+    ToolKind.SwitchMode -> V1ToolKind.SWITCH_MODE
+    ToolKind.Other -> V1ToolKind.OTHER
+    is ToolKind.Unknown -> throw unknownV2EnumVariant("ToolKind", value)
+}
+
+/**
+ * Converts this v1 kind to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1ToolKind.toV2(): ToolKind = when (this) {
+    V1ToolKind.READ -> ToolKind.Read
+    V1ToolKind.EDIT -> ToolKind.Edit
+    V1ToolKind.DELETE -> ToolKind.Delete
+    V1ToolKind.MOVE -> ToolKind.Move
+    V1ToolKind.SEARCH -> ToolKind.Search
+    V1ToolKind.EXECUTE -> ToolKind.Execute
+    V1ToolKind.THINK -> ToolKind.Think
+    V1ToolKind.FETCH -> ToolKind.Fetch
+    V1ToolKind.SWITCH_MODE -> ToolKind.SwitchMode
+    V1ToolKind.OTHER -> ToolKind.Other
+}
+
+/**
+ * Converts this v2 status to its v1 equivalent.
+ *
+ * @throws ProtocolConversionException if this is an [ToolCallStatus.Unknown] value,
+ * which cannot be represented in v1 without data loss
+ */
+@UnstableApi
+public fun ToolCallStatus.toV1(): V1ToolCallStatus = when (this) {
+    ToolCallStatus.Pending -> V1ToolCallStatus.PENDING
+    ToolCallStatus.InProgress -> V1ToolCallStatus.IN_PROGRESS
+    ToolCallStatus.Completed -> V1ToolCallStatus.COMPLETED
+    ToolCallStatus.Failed -> V1ToolCallStatus.FAILED
+    is ToolCallStatus.Unknown -> throw unknownV2EnumVariant("ToolCallStatus", value)
+}
+
+/**
+ * Converts this v1 status to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1ToolCallStatus.toV2(): ToolCallStatus = when (this) {
+    V1ToolCallStatus.PENDING -> ToolCallStatus.Pending
+    V1ToolCallStatus.IN_PROGRESS -> ToolCallStatus.InProgress
+    V1ToolCallStatus.COMPLETED -> ToolCallStatus.Completed
+    V1ToolCallStatus.FAILED -> ToolCallStatus.Failed
+}
+
+// Tool call content crosses versions only as plain content blocks: v2's structured diffs
+// and v1's `oldText`/`newText` diffs have no faithful mutual representation, v1's
+// `terminal` variant was removed in v2, and v1's `content` variant has no `_meta` field.
+// Items that cannot cross are dropped, mirroring the Rust conversion's skip-on-error
+// handling of tool call content collections. This is why neither `ToolCallContent` union
+// exposes a public conversion.
+
+private fun ToolCallContent.toV1OrNull(): V1ToolCallContent? = when (this) {
+    // A v2 content item carrying chunk metadata would lose it in v1, so it does not cross.
+    is ToolCallContent.Content -> if (_meta != null) {
+        null
+    } else {
+        try {
+            V1ToolCallContent.Content(content = content.toV1())
+        } catch (_: ProtocolConversionException) {
+            null
+        }
+    }
+
+    is ToolCallContent.Diff, is ToolCallContent.Unknown -> null
+}
+
+private fun V1ToolCallContent.toV2OrNull(): ToolCallContent? = when (this) {
+    is V1ToolCallContent.Content -> ToolCallContent.Content(content = content.toV2())
+    is V1ToolCallContent.Diff, is V1ToolCallContent.Terminal -> null
+}
+
+/**
+ * Converts this v2 tool call upsert to its v1 equivalent.
+ *
+ * v1 has no patch semantics, so the tri-state fields collapse: a value becomes a set field,
+ * while both "no update" and an explicit clear become an unset field. Collections are the
+ * exception — an explicit clear becomes an empty list, because that is how v1 expresses
+ * "no content". Fields whose own conversion fails (an [ToolKind.Unknown] kind, say) are
+ * dropped rather than failing the whole update, and content items with no v1 representation
+ * are skipped.
+ *
+ * @throws ProtocolConversionException if [ToolCallUpdate._meta] is an explicit clear, which
+ * v1 cannot express
+ */
+@UnstableApi
+public fun ToolCallUpdate.toV1(): V1SessionUpdate.ToolCallUpdate = V1SessionUpdate.ToolCallUpdate(
+    toolCallId = toolCallId,
+    title = title.valueOrNull(),
+    kind = kind.toV1OrNull { it.toV1() },
+    status = status.toV1OrNull { it.toV1() },
+    content = content.toV1ListOrNull { item -> item.toV1OrNull() },
+    locations = locations.toV1ListOrNull { it },
+    rawInput = rawInput.valueOrNull(),
+    rawOutput = rawOutput.valueOrNull(),
+    _meta = when (_meta) {
+        is MaybeUndefined.Value -> (_meta as MaybeUndefined.Value).value
+        MaybeUndefined.Null -> throw ProtocolConversionException(
+            "v2 ToolCallUpdate with null _meta cannot be represented in v1"
+        )
+        MaybeUndefined.Undefined -> null
+    },
+)
+
+/**
+ * Converts this v1 tool call creation to its v2 equivalent.
+ *
+ * v2 has no separate creation update: a tool call is created by the first upsert carrying
+ * its ID. Values that v1 uses as defaults are left as "no update" so they do not overwrite
+ * client defaults — an `other` kind, a `pending` status, and empty collections.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1SessionUpdate.ToolCall.toV2(): ToolCallUpdate = ToolCallUpdate(
+    toolCallId = toolCallId,
+    title = MaybeUndefined.Value(title),
+    kind = if (kind == null || kind == V1ToolKind.OTHER) {
+        MaybeUndefined.Undefined
+    } else {
+        MaybeUndefined.Value(kind.toV2())
+    },
+    status = if (status == null || status == V1ToolCallStatus.PENDING) {
+        MaybeUndefined.Undefined
+    } else {
+        MaybeUndefined.Value(status.toV2())
+    },
+    content = content.toV2ValueIfNotEmpty { it.toV2OrNull() },
+    locations = locations.toV2ValueIfNotEmpty { it },
+    rawInput = rawInput.toV2MaybeUndefined(),
+    rawOutput = rawOutput.toV2MaybeUndefined(),
+    _meta = _meta.toV2MaybeUndefined(),
+)
+
+/**
+ * Converts this v1 tool call update to its v2 equivalent.
+ *
+ * An unset v1 field becomes "no update" rather than an explicit clear, since v1 cannot
+ * distinguish the two. Content items with no v2 representation are skipped.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1SessionUpdate.ToolCallUpdate.toV2(): ToolCallUpdate = ToolCallUpdate(
+    toolCallId = toolCallId,
+    title = title.toV2MaybeUndefined(),
+    kind = kind?.let { MaybeUndefined.Value(it.toV2()) } ?: MaybeUndefined.Undefined,
+    status = status?.let { MaybeUndefined.Value(it.toV2()) } ?: MaybeUndefined.Undefined,
+    content = content?.let { items -> MaybeUndefined.Value(items.mapNotNull { it.toV2OrNull() }) }
+        ?: MaybeUndefined.Undefined,
+    locations = locations?.let { MaybeUndefined.Value(it) } ?: MaybeUndefined.Undefined,
+    rawInput = rawInput.toV2MaybeUndefined(),
+    rawOutput = rawOutput.toV2MaybeUndefined(),
+    _meta = _meta.toV2MaybeUndefined(),
+)
+
+/**
+ * A v1 optional value as a v2 patch state. An absent v1 value is "no update", never an
+ * explicit clear — v1 cannot express the difference.
+ */
+internal fun <T> T?.toV2MaybeUndefined(): MaybeUndefined<T> =
+    if (this == null) MaybeUndefined.Undefined else MaybeUndefined.Value(this)
+
+/**
+ * A v2 patch state as a v1 optional value, dropping values whose conversion fails.
+ */
+private inline fun <T, R> MaybeUndefined<T>.toV1OrNull(convert: (T) -> R): R? = when (this) {
+    is MaybeUndefined.Value -> try {
+        convert(value)
+    } catch (_: ProtocolConversionException) {
+        null
+    }
+
+    MaybeUndefined.Null, MaybeUndefined.Undefined -> null
+}
+
+/**
+ * A v2 patch state over a collection as a v1 optional list: an explicit clear becomes an
+ * empty list, "no update" becomes absent, and items that cannot cross are skipped.
+ */
+private inline fun <T, R> MaybeUndefined<List<T>>.toV1ListOrNull(convert: (T) -> R?): List<R>? =
+    when (this) {
+        is MaybeUndefined.Value -> value.mapNotNull(convert)
+        MaybeUndefined.Null -> emptyList()
+        MaybeUndefined.Undefined -> null
+    }
+
+/**
+ * A v1 collection as a v2 patch state: an empty v1 collection is "no update", so it does not
+ * clear whatever the receiver already has.
+ */
+private inline fun <T, R> List<T>.toV2ValueIfNotEmpty(convert: (T) -> R?): MaybeUndefined<List<R>> =
+    if (isEmpty()) MaybeUndefined.Undefined else MaybeUndefined.Value(mapNotNull(convert))

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/TypesConversions.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/TypesConversions.kt
@@ -1,0 +1,31 @@
+@file:Suppress("unused")
+
+package com.agentclientprotocol.model.v2.conversion
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.Role as V1Role
+import com.agentclientprotocol.model.v2.Role
+
+/**
+ * Converts this v2 role to its v1 equivalent.
+ *
+ * @throws ProtocolConversionException if this is an [Role.Unknown] value,
+ * which cannot be represented in v1 without data loss
+ */
+@UnstableApi
+public fun Role.toV1(): V1Role = when (this) {
+    Role.Assistant -> V1Role.ASSISTANT
+    Role.User -> V1Role.USER
+    is Role.Unknown -> throw unknownV2EnumVariant("Role", value)
+}
+
+/**
+ * Converts this v1 role to its v2 equivalent.
+ *
+ * This conversion is total: every v1 value has a v2 representation.
+ */
+@UnstableApi
+public fun V1Role.toV2(): Role = when (this) {
+    V1Role.ASSISTANT -> Role.Assistant
+    V1Role.USER -> Role.User
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/AuthMethodTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/AuthMethodTest.kt
@@ -1,0 +1,208 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.AuthEnvVar
+import com.agentclientprotocol.model.AuthMethodId
+import com.agentclientprotocol.model.EnvVariable
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.AuthMethod as V1AuthMethod
+
+class AuthMethodTest {
+
+    // Known variants
+
+    @Test
+    fun `decodes known variants`() {
+        assertEquals(
+            AuthMethod.Agent(methodId = AuthMethodId("oauth"), name = "Log in"),
+            decode("""{"type":"agent","methodId":"oauth","name":"Log in"}"""),
+        )
+        assertEquals(
+            AuthMethod.EnvVar(
+                methodId = AuthMethodId("api-key"),
+                name = "API Key",
+                vars = listOf(AuthEnvVar(name = "API_KEY")),
+            ),
+            decode("""{"type":"env_var","methodId":"api-key","name":"API Key","vars":[{"name":"API_KEY"}]}"""),
+        )
+        assertEquals(
+            AuthMethod.Terminal(methodId = AuthMethodId("login"), name = "Terminal login"),
+            decode("""{"type":"terminal","methodId":"login","name":"Terminal login"}"""),
+        )
+    }
+
+    @Test
+    fun `encodes known variants with leading discriminator`() {
+        assertEquals(
+            """{"type":"agent","methodId":"oauth","name":"Log in"}""",
+            encode(AuthMethod.Agent(methodId = AuthMethodId("oauth"), name = "Log in")),
+        )
+        assertEquals(
+            """{"type":"terminal","methodId":"login","name":"Terminal login","args":[],"env":[]}""",
+            encode(AuthMethod.Terminal(methodId = AuthMethodId("login"), name = "Terminal login")),
+        )
+    }
+
+    @Test
+    fun `known variants round-trip`() {
+        val envVar = AuthMethod.EnvVar(
+            methodId = AuthMethodId("api-key"),
+            name = "API Key",
+            description = "Provide your key",
+            vars = listOf(AuthEnvVar(name = "API_KEY", label = "Key", secret = true, optional = false)),
+            link = "https://example.com/keys",
+        )
+
+        assertEquals(envVar, decode(encode(envVar)))
+    }
+
+    // Unknown discriminators (forward compatibility)
+
+    @Test
+    fun `decodes unknown method as Unknown with parsed identity and full payload`() {
+        val json = """{"type":"oauth","methodId":"m1","name":"OAuth","authUrl":"https://example.com/auth"}"""
+
+        val method = decode(json)
+
+        assertIs<AuthMethod.Unknown>(method)
+        assertEquals("oauth", method.type)
+        assertEquals(AuthMethodId("m1"), method.methodId)
+        assertEquals("OAuth", method.name)
+        assertEquals(json, encode(method))
+    }
+
+    @Test
+    fun `unknown method without methodId fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"type":"oauth","id":"m1","name":"OAuth"}""")
+        }
+    }
+
+    // Strictness
+
+    @Test
+    fun `missing discriminator fails instead of defaulting to agent`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"methodId":"oauth","name":"Log in"}""")
+        }
+    }
+
+    @Test
+    fun `known discriminator with malformed payload fails instead of falling back`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"type":"env_var","methodId":"api-key","name":"API Key"}""")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts known variants to v1 mapping methodId to id`() {
+        assertEquals(
+            V1AuthMethod.AgentAuth(id = AuthMethodId("oauth"), name = "Log in"),
+            AuthMethod.Agent(methodId = AuthMethodId("oauth"), name = "Log in").toV1(),
+        )
+        assertEquals(
+            V1AuthMethod.TerminalAuth(
+                id = AuthMethodId("login"),
+                name = "Terminal login",
+                args = listOf("--login"),
+                env = mapOf("MODE" to "tui"),
+            ),
+            AuthMethod.Terminal(
+                methodId = AuthMethodId("login"),
+                name = "Terminal login",
+                args = listOf("--login"),
+                env = listOf(EnvVariable("MODE", "tui")),
+            ).toV1(),
+        )
+    }
+
+    @Test
+    fun `converts empty terminal args and env to absent v1 values`() {
+        val v1 = AuthMethod.Terminal(methodId = AuthMethodId("login"), name = "Terminal login").toV1()
+
+        assertEquals(
+            V1AuthMethod.TerminalAuth(id = AuthMethodId("login"), name = "Terminal login", args = null, env = null),
+            v1,
+        )
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of fabricating a payload`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            AuthMethod.Unknown(
+                type = "oauth",
+                methodId = AuthMethodId("m1"),
+                name = "OAuth",
+                rawJson = buildJsonObject { put("type", "oauth") },
+            ).toV1()
+        }
+
+        assertEquals("v2 AuthMethod variant `oauth` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converts v1 variants to v2 mapping id to methodId`() {
+        assertEquals(
+            AuthMethod.Agent(methodId = AuthMethodId("oauth"), name = "Log in"),
+            V1AuthMethod.AgentAuth(id = AuthMethodId("oauth"), name = "Log in").toV2(),
+        )
+        assertEquals(
+            AuthMethod.EnvVar(
+                methodId = AuthMethodId("api-key"),
+                name = "API Key",
+                vars = listOf(AuthEnvVar(name = "API_KEY")),
+            ),
+            V1AuthMethod.EnvVarAuth(
+                id = AuthMethodId("api-key"),
+                name = "API Key",
+                vars = listOf(AuthEnvVar(name = "API_KEY")),
+            ).toV2(),
+        )
+        assertEquals(
+            AuthMethod.Terminal(
+                methodId = AuthMethodId("login"),
+                name = "Terminal login",
+                env = listOf(EnvVariable("MODE", "tui")),
+            ),
+            V1AuthMethod.TerminalAuth(
+                id = AuthMethodId("login"),
+                name = "Terminal login",
+                env = mapOf("MODE" to "tui"),
+            ).toV2(),
+        )
+    }
+
+    @Test
+    fun `converting v1 UnknownAuthMethod to v2 fails instead of fabricating a payload`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            V1AuthMethod.UnknownAuthMethod(
+                id = AuthMethodId("m1"),
+                name = "OAuth",
+                type = "oauth",
+                rawJson = buildJsonObject { put("type", "oauth") },
+            ).toV2()
+        }
+
+        assertEquals("v1 AuthMethod variant `oauth` cannot be represented in v2", exception.message)
+    }
+
+    private fun decode(json: String): AuthMethod =
+        ACPJson.decodeFromString(AuthMethod.serializer(), json)
+
+    private fun encode(method: AuthMethod): String =
+        ACPJson.encodeToString(AuthMethod.serializer(), method)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/AvailableCommandInputTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/AvailableCommandInputTest.kt
@@ -1,0 +1,109 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.AvailableCommandInput as V1AvailableCommandInput
+
+class AvailableCommandInputTest {
+
+    // Known variants
+
+    @Test
+    fun `decodes the text variant`() {
+        assertEquals(
+            AvailableCommandInput.Text(hint = "file path"),
+            decode("""{"type":"text","hint":"file path"}"""),
+        )
+    }
+
+    @Test
+    fun `encodes the text variant with leading discriminator`() {
+        assertEquals(
+            """{"type":"text","hint":"file path"}""",
+            encode(AvailableCommandInput.Text(hint = "file path")),
+        )
+    }
+
+    // Unknown discriminators (forward compatibility)
+
+    @Test
+    fun `decodes unknown input type as Unknown preserving the full payload`() {
+        val json = """{"type":"structured","schema":{"kind":"object"}}"""
+
+        val input = decode(json)
+
+        assertIs<AvailableCommandInput.Unknown>(input)
+        assertEquals("structured", input.type)
+        assertEquals(json, encode(input))
+    }
+
+    @Test
+    fun `underscore-prefixed extension input round-trips byte-identically`() {
+        val json = """{"type":"_vendor_input","fields":[1,2,3]}"""
+
+        assertEquals(json, encode(decode(json)))
+    }
+
+    // Strictness
+
+    @Test
+    fun `missing discriminator fails instead of defaulting to a known variant`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"hint":"file path"}""")
+        }
+    }
+
+    @Test
+    fun `known discriminator with malformed payload fails instead of falling back`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"type":"text"}""")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts text to v1 unstructured`() {
+        assertEquals(
+            V1AvailableCommandInput.Unstructured(hint = "file path"),
+            AvailableCommandInput.Text(hint = "file path").toV1(),
+        )
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            AvailableCommandInput.Unknown("structured", buildJsonObject {}).toV1()
+        }
+
+        assertEquals(
+            "v2 AvailableCommandInput variant `structured` cannot be represented in v1",
+            exception.message,
+        )
+    }
+
+    @Test
+    fun `converts v1 unstructured to v2 text`() {
+        assertEquals(
+            AvailableCommandInput.Text(hint = "file path"),
+            V1AvailableCommandInput.Unstructured(hint = "file path").toV2(),
+        )
+    }
+
+    private fun decode(json: String): AvailableCommandInput =
+        ACPJson.decodeFromString(AvailableCommandInput.serializer(), json)
+
+    private fun encode(input: AvailableCommandInput): String =
+        ACPJson.encodeToString(AvailableCommandInput.serializer(), input)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/AvailableCommandsUpdateTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/AvailableCommandsUpdateTest.kt
@@ -1,0 +1,75 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+class AvailableCommandsUpdateTest {
+
+    private val update = AvailableCommandsUpdate(
+        availableCommands = listOf(
+            AvailableCommand(
+                name = "create_plan",
+                description = "Draft an implementation plan",
+                input = AvailableCommandInput.Text(hint = "goal"),
+            ),
+            AvailableCommand(name = "research_codebase", description = "Search the codebase"),
+        ),
+    )
+
+    private val updateJson =
+        """{"availableCommands":[""" +
+            """{"name":"create_plan","description":"Draft an implementation plan",""" +
+            """"input":{"type":"text","hint":"goal"}},""" +
+            """{"name":"research_codebase","description":"Search the codebase"}]}"""
+
+    @Test
+    fun `decodes commands with and without input`() {
+        assertEquals(update, decode(updateJson))
+    }
+
+    @Test
+    fun `encodes the full command set`() {
+        assertEquals(updateJson, encode(update))
+    }
+
+    @Test
+    fun `preserves unknown command input types as raw json`() {
+        val json = """{"availableCommands":[{"name":"c","description":"d","input":{"type":"_vendor","x":1}}]}"""
+
+        val decoded = decode(json)
+        val input = decoded.availableCommands.single().input
+        assertIs<AvailableCommandInput.Unknown>(input)
+        assertEquals("_vendor", input.type)
+        assertEquals(json, encode(decoded))
+    }
+
+    @Test
+    fun `decodes an empty command set`() {
+        assertEquals(AvailableCommandsUpdate(availableCommands = emptyList()), decode("""{"availableCommands":[]}"""))
+    }
+
+    @Test
+    fun `requires the command list`() {
+        assertFailsWith<SerializationException> { decode("""{}""") }
+    }
+
+    @Test
+    fun `requires a name and description on each command`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"availableCommands":[{"name":"create_plan"}]}""")
+        }
+    }
+
+    private fun decode(json: String): AvailableCommandsUpdate =
+        ACPJson.decodeFromString(AvailableCommandsUpdate.serializer(), json)
+
+    private fun encode(update: AvailableCommandsUpdate): String =
+        ACPJson.encodeToString(AvailableCommandsUpdate.serializer(), update)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ConfigOptionUpdateTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ConfigOptionUpdateTest.kt
@@ -1,0 +1,69 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.SessionConfigId
+import com.agentclientprotocol.model.SessionConfigSelectOption
+import com.agentclientprotocol.model.SessionConfigValueId
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class ConfigOptionUpdateTest {
+
+    private val update = ConfigOptionUpdate(
+        configOptions = listOf(
+            SessionConfigOption(
+                configId = SessionConfigId("model"),
+                name = "Model",
+                category = SessionConfigOptionCategory.Model,
+                kind = SessionConfigKind.Select(
+                    currentValue = SessionConfigValueId("fast"),
+                    options = SessionConfigSelectOptions.Ungrouped(
+                        listOf(SessionConfigSelectOption(value = SessionConfigValueId("fast"), name = "Fast")),
+                    ),
+                ),
+            ),
+            SessionConfigOption(
+                configId = SessionConfigId("verbose"),
+                name = "Verbose",
+                kind = SessionConfigKind.Boolean(currentValue = true),
+            ),
+        ),
+    )
+
+    private val updateJson =
+        """{"configOptions":[""" +
+            """{"type":"select","configId":"model","name":"Model","category":"model",""" +
+            """"currentValue":"fast","options":[{"value":"fast","name":"Fast"}]},""" +
+            """{"type":"boolean","configId":"verbose","name":"Verbose","currentValue":true}]}"""
+
+    @Test
+    fun `decodes the full set of config options`() {
+        assertEquals(update, decode(updateJson))
+    }
+
+    @Test
+    fun `encodes the full set of config options`() {
+        assertEquals(updateJson, encode(update))
+    }
+
+    @Test
+    fun `decodes an empty option set`() {
+        assertEquals(ConfigOptionUpdate(configOptions = emptyList()), decode("""{"configOptions":[]}"""))
+    }
+
+    @Test
+    fun `requires the option list`() {
+        assertFailsWith<SerializationException> { decode("""{}""") }
+    }
+
+    private fun decode(json: String): ConfigOptionUpdate =
+        ACPJson.decodeFromString(ConfigOptionUpdate.serializer(), json)
+
+    private fun encode(update: ConfigOptionUpdate): String =
+        ACPJson.encodeToString(ConfigOptionUpdate.serializer(), update)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ContentBlockTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ContentBlockTest.kt
@@ -1,0 +1,247 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import com.agentclientprotocol.model.ContentBlock as V1ContentBlock
+import com.agentclientprotocol.model.Role as V1Role
+
+class ContentBlockTest {
+
+    // Known variants
+
+    @Test
+    fun `decodes all known variants`() {
+        assertEquals(
+            ContentBlock.Text(text = "hello"),
+            decode("""{"type":"text","text":"hello"}"""),
+        )
+        assertEquals(
+            ContentBlock.Image(data = "aGk=", mimeType = "image/png"),
+            decode("""{"type":"image","data":"aGk=","mimeType":"image/png"}"""),
+        )
+        assertEquals(
+            ContentBlock.Audio(data = "aGk=", mimeType = "audio/wav"),
+            decode("""{"type":"audio","data":"aGk=","mimeType":"audio/wav"}"""),
+        )
+        assertEquals(
+            ContentBlock.ResourceLink(name = "main.rs", uri = "file:///main.rs"),
+            decode("""{"type":"resource_link","name":"main.rs","uri":"file:///main.rs"}"""),
+        )
+        assertEquals(
+            ContentBlock.Resource(
+                resource = EmbeddedResourceResource.TextResourceContents(text = "fn main() {}", uri = "file:///main.rs"),
+            ),
+            decode("""{"type":"resource","resource":{"text":"fn main() {}","uri":"file:///main.rs"}}"""),
+        )
+    }
+
+    @Test
+    fun `encodes text with leading discriminator`() {
+        assertEquals(
+            """{"type":"text","text":"hello"}""",
+            encode(ContentBlock.Text(text = "hello")),
+        )
+    }
+
+    @Test
+    fun `embedded resource is discriminated by shape not by a type field`() {
+        val blob = ContentBlock.Resource(
+            resource = EmbeddedResourceResource.BlobResourceContents(blob = "aGk=", uri = "file:///a.bin"),
+        )
+
+        assertEquals(
+            """{"type":"resource","resource":{"blob":"aGk=","uri":"file:///a.bin"}}""",
+            encode(blob),
+        )
+        assertEquals(blob, decode(encode(blob)))
+    }
+
+    @Test
+    fun `embedded resource without text or blob fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"type":"resource","resource":{"uri":"file:///a.bin"}}""")
+        }
+    }
+
+    @Test
+    fun `resource link with icons and annotations round-trips`() {
+        val link = ContentBlock.ResourceLink(
+            name = "main.rs",
+            uri = "file:///main.rs",
+            title = "Main",
+            icons = listOf(Icon(src = "https://example.com/icon.png", theme = IconTheme.Dark)),
+            annotations = Annotations(audience = listOf(Role.User, Role.Unknown("system")), priority = 0.5),
+        )
+
+        assertEquals(link, decode(encode(link)))
+    }
+
+    // Unknown discriminators (forward compatibility)
+
+    @Test
+    fun `decodes unknown content type as Unknown preserving the full payload`() {
+        // The priority is deliberately not a whole number: JS has a single number type, so a
+        // `1.0` literal re-emits as `1` there and byte-identity cannot hold for it.
+        val json = """{"type":"video","data":"aGk=","mimeType":"video/mp4","annotations":{"priority":0.5}}"""
+
+        val block = decode(json)
+
+        assertIs<ContentBlock.Unknown>(block)
+        assertEquals("video", block.type)
+        assertEquals(json, encode(block))
+    }
+
+    @Test
+    fun `underscore-prefixed extension content round-trips byte-identically`() {
+        val json = """{"type":"_vendor_widget","payload":{"nested":[1,2,3]}}"""
+
+        assertEquals(json, encode(decode(json)))
+    }
+
+    // Strictness
+
+    @Test
+    fun `missing discriminator fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"text":"hello"}""")
+        }
+    }
+
+    @Test
+    fun `known discriminator with malformed payload fails instead of falling back`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"type":"image","data":"aGk="}""")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts known variants to v1`() {
+        assertEquals(
+            V1ContentBlock.Text(text = "hello"),
+            ContentBlock.Text(text = "hello").toV1(),
+        )
+        assertEquals(
+            V1ContentBlock.Resource(
+                resource = com.agentclientprotocol.model.EmbeddedResourceResource.TextResourceContents(
+                    text = "fn main() {}",
+                    uri = "file:///main.rs",
+                ),
+            ),
+            ContentBlock.Resource(
+                resource = EmbeddedResourceResource.TextResourceContents(text = "fn main() {}", uri = "file:///main.rs"),
+            ).toV1(),
+        )
+    }
+
+    @Test
+    fun `converting to v1 skips audience roles with no v1 representation`() {
+        val block = ContentBlock.Text(
+            text = "hello",
+            annotations = Annotations(audience = listOf(Role.User, Role.Unknown("system"))),
+        ).toV1()
+
+        assertEquals(listOf(V1Role.USER), (block as V1ContentBlock.Text).annotations?.audience)
+    }
+
+    @Test
+    fun `converting resource link with icons to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            ContentBlock.ResourceLink(
+                name = "main.rs",
+                uri = "file:///main.rs",
+                icons = listOf(Icon(src = "https://example.com/icon.png")),
+            ).toV1()
+        }
+
+        assertEquals("v2 ResourceLink.icons cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converting resource link with empty icons to v1 succeeds`() {
+        val v1 = ContentBlock.ResourceLink(name = "main.rs", uri = "file:///main.rs", icons = emptyList()).toV1()
+
+        assertEquals(V1ContentBlock.ResourceLink(name = "main.rs", uri = "file:///main.rs"), v1)
+        assertNull((v1 as V1ContentBlock.ResourceLink).annotations)
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            ContentBlock.Unknown("video", buildJsonObject {}).toV1()
+        }
+
+        assertEquals("v2 ContentBlock variant `video` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converts all v1 variants to v2`() {
+        assertEquals(
+            ContentBlock.Text(text = "hello"),
+            V1ContentBlock.Text(text = "hello").toV2(),
+        )
+        assertEquals(
+            ContentBlock.Image(data = "aGk=", mimeType = "image/png", uri = "file:///a.png"),
+            V1ContentBlock.Image(data = "aGk=", mimeType = "image/png", uri = "file:///a.png").toV2(),
+        )
+        assertEquals(
+            ContentBlock.Audio(data = "aGk=", mimeType = "audio/wav"),
+            V1ContentBlock.Audio(data = "aGk=", mimeType = "audio/wav").toV2(),
+        )
+        assertEquals(
+            ContentBlock.ResourceLink(name = "main.rs", uri = "file:///main.rs", size = 42L),
+            V1ContentBlock.ResourceLink(name = "main.rs", uri = "file:///main.rs", size = 42L).toV2(),
+        )
+        assertEquals(
+            ContentBlock.Resource(
+                resource = EmbeddedResourceResource.BlobResourceContents(blob = "aGk=", uri = "file:///a.bin"),
+            ),
+            V1ContentBlock.Resource(
+                resource = com.agentclientprotocol.model.EmbeddedResourceResource.BlobResourceContents(
+                    blob = "aGk=",
+                    uri = "file:///a.bin",
+                ),
+            ).toV2(),
+        )
+    }
+
+    @Test
+    fun `converts v1 annotations to v2 totally`() {
+        val v2 = V1ContentBlock.Text(
+            text = "hello",
+            annotations = com.agentclientprotocol.model.Annotations(
+                audience = listOf(V1Role.ASSISTANT),
+                priority = 1.0,
+                lastModified = "2025-01-12T15:00:58Z",
+            ),
+        ).toV2()
+
+        assertEquals(
+            Annotations(
+                audience = listOf(Role.Assistant),
+                priority = 1.0,
+                lastModified = "2025-01-12T15:00:58Z",
+            ),
+            (v2 as ContentBlock.Text).annotations,
+        )
+    }
+
+    private fun decode(json: String): ContentBlock =
+        ACPJson.decodeFromString(ContentBlock.serializer(), json)
+
+    private fun encode(block: ContentBlock): String =
+        ACPJson.encodeToString(ContentBlock.serializer(), block)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ContentChunkTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ContentChunkTest.kt
@@ -1,0 +1,60 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.MessageId
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class ContentChunkTest {
+
+    private val chunk = ContentChunk(
+        messageId = MessageId("msg_1"),
+        content = ContentBlock.Text(text = "hello"),
+    )
+
+    private val chunkJson = """{"messageId":"msg_1","content":{"type":"text","text":"hello"}}"""
+
+    @Test
+    fun `decodes a chunk with its message id and content block`() {
+        assertEquals(chunk, decode(chunkJson))
+    }
+
+    @Test
+    fun `encodes a chunk without optional meta`() {
+        assertEquals(chunkJson, encode(chunk))
+    }
+
+    @Test
+    fun `round-trips chunk-scoped meta`() {
+        val withMeta = chunk.copy(_meta = buildJsonObject { put("index", JsonPrimitive(3)) })
+        val json = """{"messageId":"msg_1","content":{"type":"text","text":"hello"},"_meta":{"index":3}}"""
+
+        assertEquals(json, encode(withMeta))
+        assertEquals(withMeta, decode(json))
+    }
+
+    @Test
+    fun `requires a message id unlike v1 chunks`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"content":{"type":"text","text":"hello"}}""")
+        }
+    }
+
+    @Test
+    fun `requires content`() {
+        assertFailsWith<SerializationException> { decode("""{"messageId":"msg_1"}""") }
+    }
+
+    private fun decode(json: String): ContentChunk =
+        ACPJson.decodeFromString(ContentChunk.serializer(), json)
+
+    private fun encode(chunk: ContentChunk): String =
+        ACPJson.encodeToString(ContentChunk.serializer(), chunk)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ElicitationActionTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ElicitationActionTest.kt
@@ -1,0 +1,107 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.ElicitationContentValue
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.ElicitationAction as V1ElicitationAction
+
+class ElicitationActionTest {
+
+    // Known variants
+
+    @Test
+    fun `decodes known variants`() {
+        assertEquals(
+            ElicitationAction.Accept(content = mapOf("name" to ElicitationContentValue.StringValue("Ada"))),
+            decode("""{"action":"accept","content":{"name":"Ada"}}"""),
+        )
+        assertEquals(ElicitationAction.Decline, decode("""{"action":"decline"}"""))
+        assertEquals(ElicitationAction.Cancel, decode("""{"action":"cancel"}"""))
+    }
+
+    @Test
+    fun `encodes known variants with leading discriminator`() {
+        assertEquals("""{"action":"decline"}""", encode(ElicitationAction.Decline))
+        assertEquals(
+            """{"action":"accept","content":{"name":"Ada"}}""",
+            encode(ElicitationAction.Accept(content = mapOf("name" to ElicitationContentValue.StringValue("Ada")))),
+        )
+    }
+
+    // Unknown discriminators (forward compatibility)
+
+    @Test
+    fun `decodes unknown action as Unknown preserving the full payload`() {
+        val json = """{"action":"defer","until":"tomorrow"}"""
+
+        val action = decode(json)
+
+        assertIs<ElicitationAction.Unknown>(action)
+        assertEquals("defer", action.action)
+        assertEquals(json, encode(action))
+    }
+
+    @Test
+    fun `underscore-prefixed extension action round-trips byte-identically`() {
+        val json = """{"action":"_vendor_snooze","minutes":5}"""
+
+        assertEquals(json, encode(decode(json)))
+    }
+
+    // Strictness
+
+    @Test
+    fun `missing discriminator fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"content":{}}""")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts known variants to v1`() {
+        assertEquals(
+            V1ElicitationAction.Accept(content = mapOf("ok" to ElicitationContentValue.BooleanValue(true))),
+            ElicitationAction.Accept(content = mapOf("ok" to ElicitationContentValue.BooleanValue(true))).toV1(),
+        )
+        assertEquals(V1ElicitationAction.Decline, ElicitationAction.Decline.toV1())
+        assertEquals(V1ElicitationAction.Cancel, ElicitationAction.Cancel.toV1())
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            ElicitationAction.Unknown("defer", buildJsonObject {}).toV1()
+        }
+
+        assertEquals("v2 ElicitationAction variant `defer` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converts all v1 values to v2`() {
+        assertEquals(
+            ElicitationAction.Accept(content = null),
+            V1ElicitationAction.Accept(content = null).toV2(),
+        )
+        assertEquals(ElicitationAction.Decline, V1ElicitationAction.Decline.toV2())
+        assertEquals(ElicitationAction.Cancel, V1ElicitationAction.Cancel.toV2())
+    }
+
+    private fun decode(json: String): ElicitationAction =
+        ACPJson.decodeFromString(ElicitationAction.serializer(), json)
+
+    private fun encode(action: ElicitationAction): String =
+        ACPJson.encodeToString(ElicitationAction.serializer(), action)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ElicitationModeTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ElicitationModeTest.kt
@@ -1,0 +1,122 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.ElicitationId
+import com.agentclientprotocol.model.ElicitationScope
+import com.agentclientprotocol.model.SessionId
+import com.agentclientprotocol.model.ToolCallId
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+class ElicitationModeTest {
+
+    private val sessionScope = ElicitationScope.Session(sessionId = SessionId("s1"))
+
+    // Known variants
+
+    @Test
+    fun `decodes form mode with flattened session scope`() {
+        assertEquals(
+            ElicitationMode.Form(scope = sessionScope, requestedSchema = ElicitationSchema()),
+            decode("""{"mode":"form","sessionId":"s1","requestedSchema":{"type":"object"}}"""),
+        )
+    }
+
+    @Test
+    fun `decodes url mode with flattened scope and tool call`() {
+        assertEquals(
+            ElicitationMode.Url(
+                scope = ElicitationScope.Session(sessionId = SessionId("s1"), toolCallId = ToolCallId("t1")),
+                elicitationId = ElicitationId("e1"),
+                url = "https://example.com/login",
+            ),
+            decode(
+                """{"mode":"url","sessionId":"s1","toolCallId":"t1",""" +
+                    """"elicitationId":"e1","url":"https://example.com/login"}""",
+            ),
+        )
+    }
+
+    @Test
+    fun `encodes with mode first and scope flattened`() {
+        assertEquals(
+            """{"mode":"url","sessionId":"s1","elicitationId":"e1","url":"https://example.com/login"}""",
+            encode(
+                ElicitationMode.Url(
+                    scope = sessionScope,
+                    elicitationId = ElicitationId("e1"),
+                    url = "https://example.com/login",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `form mode round-trips`() {
+        val mode = ElicitationMode.Form(
+            scope = sessionScope,
+            requestedSchema = ElicitationSchema(
+                properties = mapOf("name" to ElicitationPropertySchema.StringProperty(title = "Name")),
+                required = listOf("name"),
+            ),
+        )
+
+        assertEquals(mode, decode(encode(mode)))
+    }
+
+    // Unknown discriminators (forward compatibility)
+
+    @Test
+    fun `decodes unknown mode as Unknown with parsed scope and full payload`() {
+        val json = """{"mode":"voice","sessionId":"s1","language":"en-US"}"""
+
+        val mode = decode(json)
+
+        assertIs<ElicitationMode.Unknown>(mode)
+        assertEquals("voice", mode.mode)
+        assertEquals(sessionScope, mode.scope)
+        assertEquals(json, encode(mode))
+    }
+
+    @Test
+    fun `unknown mode without a resolvable scope fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"mode":"voice","language":"en-US"}""")
+        }
+    }
+
+    // Strictness
+
+    @Test
+    fun `missing discriminator fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"sessionId":"s1","requestedSchema":{"type":"object"}}""")
+        }
+    }
+
+    @Test
+    fun `form without requestedSchema fails instead of falling back`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"mode":"form","sessionId":"s1"}""")
+        }
+    }
+
+    @Test
+    fun `ambiguous scope with both sessionId and requestId fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"mode":"form","sessionId":"s1","requestId":1,"requestedSchema":{"type":"object"}}""")
+        }
+    }
+
+    private fun decode(json: String): ElicitationMode =
+        ACPJson.decodeFromString(ElicitationMode.serializer(), json)
+
+    private fun encode(mode: ElicitationMode): String =
+        ACPJson.encodeToString(ElicitationMode.serializer(), mode)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ElicitationPropertySchemaTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ElicitationPropertySchemaTest.kt
@@ -1,0 +1,174 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.EnumOption
+import com.agentclientprotocol.model.TitledMultiSelectItems
+import com.agentclientprotocol.model.UntitledMultiSelectItems
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.ElicitationPropertySchema as V1ElicitationPropertySchema
+import com.agentclientprotocol.model.MultiSelectItems as V1MultiSelectItems
+
+class ElicitationPropertySchemaTest {
+
+    // Known variants
+
+    @Test
+    fun `decodes known variants`() {
+        assertEquals(
+            ElicitationPropertySchema.StringProperty(title = "Name", format = StringFormat.Email),
+            decode("""{"type":"string","title":"Name","format":"email"}"""),
+        )
+        assertEquals(
+            ElicitationPropertySchema.IntegerProperty(minimum = 0, maximum = 10),
+            decode("""{"type":"integer","minimum":0,"maximum":10}"""),
+        )
+        assertEquals(
+            ElicitationPropertySchema.ArrayProperty(
+                items = MultiSelectItems.StringItems(values = listOf("a", "b")),
+            ),
+            decode("""{"type":"array","items":{"type":"string","enum":["a","b"]}}"""),
+        )
+    }
+
+    @Test
+    fun `encodes with leading discriminator`() {
+        assertEquals(
+            """{"type":"boolean","title":"Verbose","default":true}""",
+            encode(ElicitationPropertySchema.BooleanProperty(title = "Verbose", default = true)),
+        )
+    }
+
+    @Test
+    fun `titled multi-select items are untagged and round-trip`() {
+        val schema = ElicitationPropertySchema.ArrayProperty(
+            items = MultiSelectItems.Titled(options = listOf(EnumOption(value = "a", title = "Option A"))),
+        )
+
+        assertEquals(
+            """{"type":"array","items":{"anyOf":[{"const":"a","title":"Option A"}]}}""",
+            encode(schema),
+        )
+        assertEquals(schema, decode(encode(schema)))
+    }
+
+    @Test
+    fun `unknown multi-select items type is preserved`() {
+        val schema = decode("""{"type":"array","items":{"type":"file","extensions":[".kt"]}}""")
+
+        assertIs<ElicitationPropertySchema.ArrayProperty>(schema)
+        val items = schema.items
+        assertIs<MultiSelectItems.Unknown>(items)
+        assertEquals("file", items.type)
+        assertEquals(schema, decode(encode(schema)))
+    }
+
+    @Test
+    fun `multi-select items without type or anyOf fail`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"type":"array","items":{"enum":["a"],"unrelated":true}}""".replace(""""enum"""", """"values""""))
+        }
+    }
+
+    // Unknown discriminators (forward compatibility)
+
+    @Test
+    fun `decodes unknown property type as Unknown preserving the full payload`() {
+        val json = """{"type":"date_range","from":"2026-01-01","to":"2026-12-31"}"""
+
+        val schema = decode(json)
+
+        assertIs<ElicitationPropertySchema.Unknown>(schema)
+        assertEquals("date_range", schema.type)
+        assertEquals(json, encode(schema))
+    }
+
+    // Strictness
+
+    @Test
+    fun `missing discriminator fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"title":"Name"}""")
+        }
+    }
+
+    @Test
+    fun `known discriminator with malformed payload fails instead of falling back`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"type":"array","title":"Tags"}""")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts known variants to v1`() {
+        assertEquals(
+            V1ElicitationPropertySchema.StringProperty(
+                title = "Name",
+                format = com.agentclientprotocol.model.StringFormat.EMAIL,
+            ),
+            ElicitationPropertySchema.StringProperty(title = "Name", format = StringFormat.Email).toV1(),
+        )
+        assertEquals(
+            V1ElicitationPropertySchema.ArrayProperty(
+                items = V1MultiSelectItems.Untitled(UntitledMultiSelectItems(values = listOf("a"))),
+            ),
+            ElicitationPropertySchema.ArrayProperty(
+                items = MultiSelectItems.StringItems(values = listOf("a")),
+            ).toV1(),
+        )
+    }
+
+    @Test
+    fun `converting unknown format to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            ElicitationPropertySchema.StringProperty(format = StringFormat.Unknown("hostname")).toV1()
+        }
+
+        assertEquals("v2 StringFormat variant `hostname` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            ElicitationPropertySchema.Unknown("date_range", buildJsonObject {}).toV1()
+        }
+
+        assertEquals("v2 ElicitationPropertySchema variant `date_range` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converts all v1 variants to v2`() {
+        assertEquals(
+            ElicitationPropertySchema.NumberProperty(minimum = 0.5, maximum = 1.5),
+            V1ElicitationPropertySchema.NumberProperty(minimum = 0.5, maximum = 1.5).toV2(),
+        )
+        assertEquals(
+            ElicitationPropertySchema.ArrayProperty(
+                items = MultiSelectItems.Titled(options = listOf(EnumOption(value = "a", title = "A"))),
+            ),
+            V1ElicitationPropertySchema.ArrayProperty(
+                items = V1MultiSelectItems.Titled(
+                    TitledMultiSelectItems(options = listOf(EnumOption(value = "a", title = "A"))),
+                ),
+            ).toV2(),
+        )
+    }
+
+    private fun decode(json: String): ElicitationPropertySchema =
+        ACPJson.decodeFromString(ElicitationPropertySchema.serializer(), json)
+
+    private fun encode(schema: ElicitationPropertySchema): String =
+        ACPJson.encodeToString(ElicitationPropertySchema.serializer(), schema)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/LlmProtocolTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/LlmProtocolTest.kt
@@ -1,0 +1,97 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.LlmProtocol as V1LlmProtocol
+
+class LlmProtocolTest {
+
+    // Known values
+
+    @Test
+    fun `decodes all known values`() {
+        assertEquals(LlmProtocol.Anthropic, decode("\"anthropic\""))
+        assertEquals(LlmProtocol.OpenAi, decode("\"openai\""))
+        assertEquals(LlmProtocol.Azure, decode("\"azure\""))
+        assertEquals(LlmProtocol.Vertex, decode("\"vertex\""))
+        assertEquals(LlmProtocol.Bedrock, decode("\"bedrock\""))
+    }
+
+    @Test
+    fun `encodes all known values`() {
+        assertEquals("\"anthropic\"", encode(LlmProtocol.Anthropic))
+        assertEquals("\"openai\"", encode(LlmProtocol.OpenAi))
+        assertEquals("\"azure\"", encode(LlmProtocol.Azure))
+        assertEquals("\"vertex\"", encode(LlmProtocol.Vertex))
+        assertEquals("\"bedrock\"", encode(LlmProtocol.Bedrock))
+    }
+
+    // Unknown values (forward compatibility)
+
+    @Test
+    fun `decodes unknown value as Unknown and round-trips byte-identically`() {
+        val protocol = decode("\"gemini\"")
+
+        assertIs<LlmProtocol.Unknown>(protocol)
+        assertEquals("gemini", protocol.value)
+        assertEquals("\"_vendor_protocol\"", encode(decode("\"_vendor_protocol\"")))
+    }
+
+    // Extension factory
+
+    @Test
+    fun `extension creates Unknown for underscore-prefixed values`() {
+        assertEquals(LlmProtocol.extension("_vendor_protocol"), LlmProtocol.Unknown("_vendor_protocol"))
+    }
+
+    @Test
+    fun `extension rejects values without underscore prefix`() {
+        assertFailsWith<IllegalArgumentException> {
+            LlmProtocol.extension("vendor_protocol")
+        }
+    }
+
+    // v2 <-> v1 conversion (total both ways: v1 is an open string wrapper)
+
+    @Test
+    fun `converts all known values to v1`() {
+        assertEquals(LlmProtocol.Anthropic.toV1(), V1LlmProtocol.ANTHROPIC)
+        assertEquals(LlmProtocol.OpenAi.toV1(), V1LlmProtocol.OPENAI)
+        assertEquals(LlmProtocol.Azure.toV1(), V1LlmProtocol.AZURE)
+        assertEquals(LlmProtocol.Vertex.toV1(), V1LlmProtocol.VERTEX)
+        assertEquals(LlmProtocol.Bedrock.toV1(), V1LlmProtocol.BEDROCK)
+    }
+
+    @Test
+    fun `converts Unknown to v1 without data loss`() {
+        assertEquals(V1LlmProtocol("gemini"), LlmProtocol.Unknown("gemini").toV1())
+    }
+
+    @Test
+    fun `converts all well-known v1 values to v2`() {
+        assertEquals(LlmProtocol.Anthropic, V1LlmProtocol.ANTHROPIC.toV2())
+        assertEquals(LlmProtocol.OpenAi, V1LlmProtocol.OPENAI.toV2())
+        assertEquals(LlmProtocol.Azure, V1LlmProtocol.AZURE.toV2())
+        assertEquals(LlmProtocol.Vertex, V1LlmProtocol.VERTEX.toV2())
+        assertEquals(LlmProtocol.Bedrock, V1LlmProtocol.BEDROCK.toV2())
+    }
+
+    @Test
+    fun `converts custom v1 value to v2 Unknown`() {
+        assertEquals(LlmProtocol.Unknown("gemini"), V1LlmProtocol("gemini").toV2())
+    }
+
+    private fun decode(json: String): LlmProtocol =
+        ACPJson.decodeFromString(LlmProtocol.serializer(), json)
+
+    private fun encode(protocol: LlmProtocol): String =
+        ACPJson.encodeToString(LlmProtocol.serializer(), protocol)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/McpServerTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/McpServerTest.kt
@@ -1,0 +1,160 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.EnvVariable
+import com.agentclientprotocol.model.HttpHeader
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.McpServer as V1McpServer
+
+class McpServerTest {
+
+    // Known variants
+
+    @Test
+    fun `decodes known variants`() {
+        assertEquals(
+            McpServer.Http(name = "srv", url = "https://example.com/mcp"),
+            decode("""{"type":"http","name":"srv","url":"https://example.com/mcp"}"""),
+        )
+        assertEquals(
+            McpServer.Stdio(name = "srv", command = "/bin/mcp", args = listOf("--fast")),
+            decode("""{"type":"stdio","name":"srv","command":"/bin/mcp","args":["--fast"]}"""),
+        )
+    }
+
+    @Test
+    fun `encodes known variants with leading discriminator`() {
+        assertEquals(
+            """{"type":"http","name":"srv","url":"https://example.com/mcp","headers":[]}""",
+            encode(McpServer.Http(name = "srv", url = "https://example.com/mcp")),
+        )
+        assertEquals(
+            """{"type":"stdio","name":"srv","command":"/bin/mcp","args":[],"env":[]}""",
+            encode(McpServer.Stdio(name = "srv", command = "/bin/mcp")),
+        )
+    }
+
+    @Test
+    fun `known variants round-trip`() {
+        val server = McpServer.Stdio(
+            name = "srv",
+            command = "/bin/mcp",
+            args = listOf("--fast"),
+            env = listOf(EnvVariable("KEY", "value")),
+        )
+
+        assertEquals(server, decode(encode(server)))
+
+        val http = McpServer.Http(
+            name = "srv",
+            url = "https://example.com/mcp",
+            headers = listOf(HttpHeader("Authorization", "Bearer token")),
+        )
+
+        assertEquals(http, decode(encode(http)))
+    }
+
+    // Unknown discriminators (forward compatibility)
+
+    @Test
+    fun `decodes unknown transport as Unknown preserving the full payload`() {
+        val json = """{"type":"websocket","name":"srv","endpoint":"wss://example.com"}"""
+
+        val server = decode(json)
+
+        assertIs<McpServer.Unknown>(server)
+        assertEquals("websocket", server.type)
+        assertEquals(json, encode(server))
+    }
+
+    @Test
+    fun `underscore-prefixed extension transport round-trips byte-identically`() {
+        val json = """{"type":"_vendor_transport","name":"srv","custom":{"nested":[1,2]}}"""
+
+        assertEquals(json, encode(decode(json)))
+    }
+
+    // Strictness (the v1 default-to-Stdio hazard is gone)
+
+    @Test
+    fun `missing discriminator fails instead of defaulting to stdio`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"name":"srv","command":"/bin/mcp","args":[],"env":[]}""")
+        }
+    }
+
+    @Test
+    fun `known discriminator with malformed payload fails instead of falling back`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"type":"http","name":"srv"}""")
+        }
+    }
+
+    @Test
+    fun `non-string discriminator fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"type":42,"name":"srv"}""")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts known variants to v1`() {
+        assertEquals(
+            V1McpServer.Http(name = "srv", url = "https://example.com/mcp", headers = emptyList()),
+            McpServer.Http(name = "srv", url = "https://example.com/mcp").toV1(),
+        )
+        assertEquals(
+            V1McpServer.Stdio(name = "srv", command = "/bin/mcp", args = emptyList(), env = emptyList()),
+            McpServer.Stdio(name = "srv", command = "/bin/mcp").toV1(),
+        )
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            McpServer.Unknown("websocket", buildJsonObject {}).toV1()
+        }
+
+        assertEquals("v2 McpServer variant `websocket` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converts v1 variants to v2`() {
+        assertEquals(
+            McpServer.Http(name = "srv", url = "https://example.com/mcp"),
+            V1McpServer.Http(name = "srv", url = "https://example.com/mcp", headers = emptyList()).toV2(),
+        )
+        assertEquals(
+            McpServer.Stdio(name = "srv", command = "/bin/mcp"),
+            V1McpServer.Stdio(name = "srv", command = "/bin/mcp", args = emptyList(), env = emptyList()).toV2(),
+        )
+    }
+
+    @Test
+    fun `converting v1 Sse to v2 fails because the transport was removed`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            V1McpServer.Sse(name = "srv", url = "https://example.com/sse", headers = emptyList()).toV2()
+        }
+
+        assertEquals("v1 McpServer variant `sse` cannot be represented in v2", exception.message)
+    }
+
+    private fun decode(json: String): McpServer =
+        ACPJson.decodeFromString(McpServer.serializer(), json)
+
+    private fun encode(server: McpServer): String =
+        ACPJson.encodeToString(McpServer.serializer(), server)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/MessageUpsertTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/MessageUpsertTest.kt
@@ -1,0 +1,133 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.MessageId
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * [UserMessage], [AgentMessage], and [AgentThought] share one wire shape and one
+ * serializer base, so they are covered together.
+ */
+class MessageUpsertTest {
+
+    // Encoding: Undefined is omitted, Null is an explicit null, Value is encoded
+
+    @Test
+    fun `encodes only set fields as an upsert`() {
+        assertEquals("""{"messageId":"msg_1"}""", encodeUser(UserMessage(messageId = MessageId("msg_1"))))
+        assertEquals(
+            """{"messageId":"msg_1","content":[{"type":"text","text":"hi"}]}""",
+            encodeUser(
+                UserMessage(
+                    messageId = MessageId("msg_1"),
+                    content = MaybeUndefined.Value(listOf(ContentBlock.Text(text = "hi"))),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `encodes an explicit null for cleared content and meta`() {
+        assertEquals(
+            """{"messageId":"msg_1","content":null,"_meta":null}""",
+            encodeUser(
+                UserMessage(
+                    messageId = MessageId("msg_1"),
+                    content = MaybeUndefined.Null,
+                    _meta = MaybeUndefined.Null,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `all three upserts share the same wire shape`() {
+        val json = """{"messageId":"msg_1","content":[{"type":"text","text":"hi"}]}"""
+        val content = MaybeUndefined.Value(listOf<ContentBlock>(ContentBlock.Text(text = "hi")))
+
+        assertEquals(json, encodeUser(UserMessage(messageId = MessageId("msg_1"), content = content)))
+        assertEquals(
+            json,
+            ACPJson.encodeToString(
+                AgentMessage.serializer(),
+                AgentMessage(messageId = MessageId("msg_1"), content = content),
+            ),
+        )
+        assertEquals(
+            json,
+            ACPJson.encodeToString(
+                AgentThought.serializer(),
+                AgentThought(messageId = MessageId("msg_1"), content = content),
+            ),
+        )
+    }
+
+    // Decoding: absent, null, and value are three distinct states
+
+    @Test
+    fun `decodes omitted null and value states distinctly`() {
+        assertEquals(MaybeUndefined.Undefined, decodeUser("""{"messageId":"msg_1"}""").content)
+        assertEquals(MaybeUndefined.Null, decodeUser("""{"messageId":"msg_1","content":null}""").content)
+        assertEquals(
+            MaybeUndefined.Value(listOf(ContentBlock.Text(text = "hi"))),
+            decodeUser("""{"messageId":"msg_1","content":[{"type":"text","text":"hi"}]}""").content,
+        )
+    }
+
+    @Test
+    fun `decodes an empty content array as a value that clears accumulated content`() {
+        assertEquals(MaybeUndefined.Value(emptyList()), decodeUser("""{"messageId":"msg_1","content":[]}""").content)
+    }
+
+    @Test
+    fun `round-trips meta`() {
+        val meta = buildJsonObject { put("source", JsonPrimitive("cli")) }
+        val message = UserMessage(messageId = MessageId("msg_1"), _meta = MaybeUndefined.Value(meta))
+        val json = """{"messageId":"msg_1","_meta":{"source":"cli"}}"""
+
+        assertEquals(json, encodeUser(message))
+        assertEquals(message, decodeUser(json))
+    }
+
+    // Graceful degradation, mirroring the Rust schema's DefaultOnError / VecSkipError
+
+    @Test
+    fun `skips malformed content items instead of failing the field`() {
+        val decoded = decodeUser(
+            """{"messageId":"msg_1","content":[{"type":"text","text":"hi"},{"type":"text"}]}""",
+        )
+
+        assertEquals(MaybeUndefined.Value(listOf(ContentBlock.Text(text = "hi"))), decoded.content)
+    }
+
+    @Test
+    fun `degrades a non-array content value to Undefined`() {
+        assertEquals(MaybeUndefined.Undefined, decodeUser("""{"messageId":"msg_1","content":"oops"}""").content)
+    }
+
+    @Test
+    fun `preserves unknown content block types`() {
+        val decoded = decodeUser("""{"messageId":"msg_1","content":[{"type":"_vendor","x":1}]}""")
+
+        assertEquals(1, (decoded.content as MaybeUndefined.Value).value.size)
+    }
+
+    @Test
+    fun `requires a message id`() {
+        assertFailsWith<SerializationException> { decodeUser("""{"content":[]}""") }
+    }
+
+    private fun decodeUser(json: String): UserMessage =
+        ACPJson.decodeFromString(UserMessage.serializer(), json)
+
+    private fun encodeUser(message: UserMessage): String =
+        ACPJson.encodeToString(UserMessage.serializer(), message)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/NesDiagnosticSeverityTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/NesDiagnosticSeverityTest.kt
@@ -1,0 +1,96 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.NesDiagnosticSeverity as V1NesDiagnosticSeverity
+
+class NesDiagnosticSeverityTest {
+
+    // Known values
+
+    @Test
+    fun `decodes all known values`() {
+        assertEquals(NesDiagnosticSeverity.Error, decode("\"error\""))
+        assertEquals(NesDiagnosticSeverity.Warning, decode("\"warning\""))
+        assertEquals(NesDiagnosticSeverity.Information, decode("\"information\""))
+        assertEquals(NesDiagnosticSeverity.Hint, decode("\"hint\""))
+    }
+
+    @Test
+    fun `encodes all known values`() {
+        assertEquals("\"error\"", encode(NesDiagnosticSeverity.Error))
+        assertEquals("\"warning\"", encode(NesDiagnosticSeverity.Warning))
+        assertEquals("\"information\"", encode(NesDiagnosticSeverity.Information))
+        assertEquals("\"hint\"", encode(NesDiagnosticSeverity.Hint))
+    }
+
+    // Unknown values (forward compatibility)
+
+    @Test
+    fun `decodes unknown value as Unknown and round-trips byte-identically`() {
+        val severity = decode("\"deprecation\"")
+
+        assertIs<NesDiagnosticSeverity.Unknown>(severity)
+        assertEquals("deprecation", severity.value)
+        assertEquals("\"_vendor_severity\"", encode(decode("\"_vendor_severity\"")))
+    }
+
+    // Extension factory
+
+    @Test
+    fun `extension creates Unknown for underscore-prefixed values`() {
+        assertEquals(
+            NesDiagnosticSeverity.extension("_vendor_severity"),
+            NesDiagnosticSeverity.Unknown("_vendor_severity"),
+        )
+    }
+
+    @Test
+    fun `extension rejects values without underscore prefix`() {
+        assertFailsWith<IllegalArgumentException> {
+            NesDiagnosticSeverity.extension("vendor_severity")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts all known values to v1`() {
+        assertEquals(V1NesDiagnosticSeverity.ERROR, NesDiagnosticSeverity.Error.toV1())
+        assertEquals(V1NesDiagnosticSeverity.WARNING, NesDiagnosticSeverity.Warning.toV1())
+        assertEquals(V1NesDiagnosticSeverity.INFORMATION, NesDiagnosticSeverity.Information.toV1())
+        assertEquals(V1NesDiagnosticSeverity.HINT, NesDiagnosticSeverity.Hint.toV1())
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            NesDiagnosticSeverity.Unknown("deprecation").toV1()
+        }
+
+        assertEquals("v2 NesDiagnosticSeverity variant `deprecation` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converts all v1 values to v2`() {
+        assertEquals(NesDiagnosticSeverity.Error, V1NesDiagnosticSeverity.ERROR.toV2())
+        assertEquals(NesDiagnosticSeverity.Warning, V1NesDiagnosticSeverity.WARNING.toV2())
+        assertEquals(NesDiagnosticSeverity.Information, V1NesDiagnosticSeverity.INFORMATION.toV2())
+        assertEquals(NesDiagnosticSeverity.Hint, V1NesDiagnosticSeverity.HINT.toV2())
+    }
+
+    private fun decode(json: String): NesDiagnosticSeverity =
+        ACPJson.decodeFromString(NesDiagnosticSeverity.serializer(), json)
+
+    private fun encode(severity: NesDiagnosticSeverity): String =
+        ACPJson.encodeToString(NesDiagnosticSeverity.serializer(), severity)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/NesRejectReasonTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/NesRejectReasonTest.kt
@@ -1,0 +1,93 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.NesRejectReason as V1NesRejectReason
+
+class NesRejectReasonTest {
+
+    // Known values
+
+    @Test
+    fun `decodes all known values`() {
+        assertEquals(NesRejectReason.Rejected, decode("\"rejected\""))
+        assertEquals(NesRejectReason.Ignored, decode("\"ignored\""))
+        assertEquals(NesRejectReason.Replaced, decode("\"replaced\""))
+        assertEquals(NesRejectReason.Cancelled, decode("\"cancelled\""))
+    }
+
+    @Test
+    fun `encodes all known values`() {
+        assertEquals("\"rejected\"", encode(NesRejectReason.Rejected))
+        assertEquals("\"ignored\"", encode(NesRejectReason.Ignored))
+        assertEquals("\"replaced\"", encode(NesRejectReason.Replaced))
+        assertEquals("\"cancelled\"", encode(NesRejectReason.Cancelled))
+    }
+
+    // Unknown values (forward compatibility)
+
+    @Test
+    fun `decodes unknown value as Unknown and round-trips byte-identically`() {
+        val reason = decode("\"expired\"")
+
+        assertIs<NesRejectReason.Unknown>(reason)
+        assertEquals("expired", reason.value)
+        assertEquals("\"_vendor_reason\"", encode(decode("\"_vendor_reason\"")))
+    }
+
+    // Extension factory
+
+    @Test
+    fun `extension creates Unknown for underscore-prefixed values`() {
+        assertEquals(NesRejectReason.extension("_vendor_reason"), NesRejectReason.Unknown("_vendor_reason"))
+    }
+
+    @Test
+    fun `extension rejects values without underscore prefix`() {
+        assertFailsWith<IllegalArgumentException> {
+            NesRejectReason.extension("vendor_reason")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts all known values to v1`() {
+        assertEquals(V1NesRejectReason.REJECTED, NesRejectReason.Rejected.toV1())
+        assertEquals(V1NesRejectReason.IGNORED, NesRejectReason.Ignored.toV1())
+        assertEquals(V1NesRejectReason.REPLACED, NesRejectReason.Replaced.toV1())
+        assertEquals(V1NesRejectReason.CANCELLED, NesRejectReason.Cancelled.toV1())
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            NesRejectReason.Unknown("expired").toV1()
+        }
+
+        assertEquals("v2 NesRejectReason variant `expired` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converts all v1 values to v2`() {
+        assertEquals(NesRejectReason.Rejected, V1NesRejectReason.REJECTED.toV2())
+        assertEquals(NesRejectReason.Ignored, V1NesRejectReason.IGNORED.toV2())
+        assertEquals(NesRejectReason.Replaced, V1NesRejectReason.REPLACED.toV2())
+        assertEquals(NesRejectReason.Cancelled, V1NesRejectReason.CANCELLED.toV2())
+    }
+
+    private fun decode(json: String): NesRejectReason =
+        ACPJson.decodeFromString(NesRejectReason.serializer(), json)
+
+    private fun encode(reason: NesRejectReason): String =
+        ACPJson.encodeToString(NesRejectReason.serializer(), reason)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/NesSuggestionTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/NesSuggestionTest.kt
@@ -1,0 +1,154 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.NesPosition
+import com.agentclientprotocol.model.NesRange
+import com.agentclientprotocol.model.NesTextEdit
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.NesSuggestion as V1NesSuggestion
+
+class NesSuggestionTest {
+
+    private val position = NesPosition(line = 1u, character = 2u)
+    private val edit = NesTextEdit(
+        range = NesRange(start = position, end = position),
+        newText = "fixed",
+    )
+
+    // Known variants
+
+    @Test
+    fun `decodes known variants`() {
+        assertEquals(
+            NesSuggestion.Jump(suggestionId = "s1", uri = "file:///main.rs", position = position),
+            decode("""{"kind":"jump","suggestionId":"s1","uri":"file:///main.rs","position":{"line":1,"character":2}}"""),
+        )
+        assertEquals(
+            NesSuggestion.Rename(suggestionId = "s2", uri = "file:///main.rs", position = position, newName = "newName"),
+            decode(
+                """{"kind":"rename","suggestionId":"s2","uri":"file:///main.rs",""" +
+                    """"position":{"line":1,"character":2},"newName":"newName"}""",
+            ),
+        )
+    }
+
+    @Test
+    fun `encodes known variants with leading discriminator`() {
+        assertEquals(
+            """{"kind":"searchAndReplace","suggestionId":"s3","uri":"file:///main.rs","search":"a","replace":"b"}""",
+            encode(
+                NesSuggestion.SearchAndReplace(
+                    suggestionId = "s3",
+                    uri = "file:///main.rs",
+                    search = "a",
+                    replace = "b",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `edit variant round-trips`() {
+        val suggestion = NesSuggestion.Edit(
+            suggestionId = "s4",
+            uri = "file:///main.rs",
+            edits = listOf(edit),
+            cursorPosition = position,
+        )
+
+        assertEquals(suggestion, decode(encode(suggestion)))
+    }
+
+    // Unknown discriminators (forward compatibility)
+
+    @Test
+    fun `decodes unknown kind as Unknown with parsed identity and full payload`() {
+        val json = """{"kind":"refactor","suggestionId":"s5","strategy":"extract-method"}"""
+
+        val suggestion = decode(json)
+
+        assertIs<NesSuggestion.Unknown>(suggestion)
+        assertEquals("refactor", suggestion.kind)
+        assertEquals("s5", suggestion.suggestionId)
+        assertEquals(json, encode(suggestion))
+    }
+
+    @Test
+    fun `unknown suggestion without suggestionId fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"kind":"refactor","id":"s5"}""")
+        }
+    }
+
+    // Strictness
+
+    @Test
+    fun `missing discriminator fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"suggestionId":"s1","uri":"file:///main.rs"}""")
+        }
+    }
+
+    @Test
+    fun `known discriminator with malformed payload fails instead of falling back`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"kind":"jump","suggestionId":"s1"}""")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts known variants to v1 mapping suggestionId to id`() {
+        assertEquals(
+            V1NesSuggestion.Jump(id = "s1", uri = "file:///main.rs", position = position),
+            NesSuggestion.Jump(suggestionId = "s1", uri = "file:///main.rs", position = position).toV1(),
+        )
+        assertEquals(
+            V1NesSuggestion.SearchAndReplace(id = "s3", uri = "file:///a", search = "a", replace = "b", isRegex = false),
+            NesSuggestion.SearchAndReplace(suggestionId = "s3", uri = "file:///a", search = "a", replace = "b").toV1(),
+        )
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            NesSuggestion.Unknown(kind = "refactor", suggestionId = "s5", rawJson = buildJsonObject {}).toV1()
+        }
+
+        assertEquals("v2 NesSuggestion variant `refactor` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converts all v1 variants to v2`() {
+        assertEquals(
+            NesSuggestion.Edit(suggestionId = "s4", uri = "file:///a", edits = listOf(edit), cursorPosition = position),
+            V1NesSuggestion.Edit(id = "s4", uri = "file:///a", edits = listOf(edit), cursorPosition = position).toV2(),
+        )
+        assertEquals(
+            NesSuggestion.Rename(suggestionId = "s2", uri = "file:///a", position = position, newName = "n"),
+            V1NesSuggestion.Rename(id = "s2", uri = "file:///a", position = position, newName = "n").toV2(),
+        )
+        assertEquals(
+            NesSuggestion.SearchAndReplace(suggestionId = "s3", uri = "file:///a", search = "a", replace = "b", isRegex = true),
+            V1NesSuggestion.SearchAndReplace(id = "s3", uri = "file:///a", search = "a", replace = "b", isRegex = true).toV2(),
+        )
+    }
+
+    private fun decode(json: String): NesSuggestion =
+        ACPJson.decodeFromString(NesSuggestion.serializer(), json)
+
+    private fun encode(suggestion: NesSuggestion): String =
+        ACPJson.encodeToString(NesSuggestion.serializer(), suggestion)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/NesTriggerKindTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/NesTriggerKindTest.kt
@@ -1,0 +1,89 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.NesTriggerKind as V1NesTriggerKind
+
+class NesTriggerKindTest {
+
+    // Known values
+
+    @Test
+    fun `decodes all known values`() {
+        assertEquals(NesTriggerKind.Automatic, decode("\"automatic\""))
+        assertEquals(NesTriggerKind.Diagnostic, decode("\"diagnostic\""))
+        assertEquals(NesTriggerKind.Manual, decode("\"manual\""))
+    }
+
+    @Test
+    fun `encodes all known values`() {
+        assertEquals("\"automatic\"", encode(NesTriggerKind.Automatic))
+        assertEquals("\"diagnostic\"", encode(NesTriggerKind.Diagnostic))
+        assertEquals("\"manual\"", encode(NesTriggerKind.Manual))
+    }
+
+    // Unknown values (forward compatibility)
+
+    @Test
+    fun `decodes unknown value as Unknown and round-trips byte-identically`() {
+        val kind = decode("\"scheduled\"")
+
+        assertIs<NesTriggerKind.Unknown>(kind)
+        assertEquals("scheduled", kind.value)
+        assertEquals("\"_vendor_trigger\"", encode(decode("\"_vendor_trigger\"")))
+    }
+
+    // Extension factory
+
+    @Test
+    fun `extension creates Unknown for underscore-prefixed values`() {
+        assertEquals(NesTriggerKind.extension("_vendor_trigger"), NesTriggerKind.Unknown("_vendor_trigger"))
+    }
+
+    @Test
+    fun `extension rejects values without underscore prefix`() {
+        assertFailsWith<IllegalArgumentException> {
+            NesTriggerKind.extension("vendor_trigger")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts all known values to v1`() {
+        assertEquals(V1NesTriggerKind.AUTOMATIC, NesTriggerKind.Automatic.toV1())
+        assertEquals(V1NesTriggerKind.DIAGNOSTIC, NesTriggerKind.Diagnostic.toV1())
+        assertEquals(V1NesTriggerKind.MANUAL, NesTriggerKind.Manual.toV1())
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            NesTriggerKind.Unknown("scheduled").toV1()
+        }
+
+        assertEquals("v2 NesTriggerKind variant `scheduled` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converts all v1 values to v2`() {
+        assertEquals(NesTriggerKind.Automatic, V1NesTriggerKind.AUTOMATIC.toV2())
+        assertEquals(NesTriggerKind.Diagnostic, V1NesTriggerKind.DIAGNOSTIC.toV2())
+        assertEquals(NesTriggerKind.Manual, V1NesTriggerKind.MANUAL.toV2())
+    }
+
+    private fun decode(json: String): NesTriggerKind =
+        ACPJson.decodeFromString(NesTriggerKind.serializer(), json)
+
+    private fun encode(kind: NesTriggerKind): String =
+        ACPJson.encodeToString(NesTriggerKind.serializer(), kind)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/PermissionOptionKindTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/PermissionOptionKindTest.kt
@@ -1,0 +1,93 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.PermissionOptionKind as V1PermissionOptionKind
+
+class PermissionOptionKindTest {
+
+    // Known values
+
+    @Test
+    fun `decodes all known values`() {
+        assertEquals(PermissionOptionKind.AllowOnce, decode("\"allow_once\""))
+        assertEquals(PermissionOptionKind.AllowAlways, decode("\"allow_always\""))
+        assertEquals(PermissionOptionKind.RejectOnce, decode("\"reject_once\""))
+        assertEquals(PermissionOptionKind.RejectAlways, decode("\"reject_always\""))
+    }
+
+    @Test
+    fun `encodes all known values`() {
+        assertEquals("\"allow_once\"", encode(PermissionOptionKind.AllowOnce))
+        assertEquals("\"allow_always\"", encode(PermissionOptionKind.AllowAlways))
+        assertEquals("\"reject_once\"", encode(PermissionOptionKind.RejectOnce))
+        assertEquals("\"reject_always\"", encode(PermissionOptionKind.RejectAlways))
+    }
+
+    // Unknown values (forward compatibility)
+
+    @Test
+    fun `decodes unknown value as Unknown and round-trips byte-identically`() {
+        val kind = decode("\"allow_scoped\"")
+
+        assertIs<PermissionOptionKind.Unknown>(kind)
+        assertEquals("allow_scoped", kind.value)
+        assertEquals("\"_vendor_kind\"", encode(decode("\"_vendor_kind\"")))
+    }
+
+    // Extension factory
+
+    @Test
+    fun `extension creates Unknown for underscore-prefixed values`() {
+        assertEquals(PermissionOptionKind.extension("_vendor_kind"), PermissionOptionKind.Unknown("_vendor_kind"))
+    }
+
+    @Test
+    fun `extension rejects values without underscore prefix`() {
+        assertFailsWith<IllegalArgumentException> {
+            PermissionOptionKind.extension("vendor_kind")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts all known values to v1`() {
+        assertEquals(V1PermissionOptionKind.ALLOW_ONCE, PermissionOptionKind.AllowOnce.toV1())
+        assertEquals(V1PermissionOptionKind.ALLOW_ALWAYS, PermissionOptionKind.AllowAlways.toV1())
+        assertEquals(V1PermissionOptionKind.REJECT_ONCE, PermissionOptionKind.RejectOnce.toV1())
+        assertEquals(V1PermissionOptionKind.REJECT_ALWAYS, PermissionOptionKind.RejectAlways.toV1())
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            PermissionOptionKind.Unknown("allow_scoped").toV1()
+        }
+
+        assertEquals("v2 PermissionOptionKind variant `allow_scoped` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converts all v1 values to v2`() {
+        assertEquals(PermissionOptionKind.AllowOnce, V1PermissionOptionKind.ALLOW_ONCE.toV2())
+        assertEquals(PermissionOptionKind.AllowAlways, V1PermissionOptionKind.ALLOW_ALWAYS.toV2())
+        assertEquals(PermissionOptionKind.RejectOnce, V1PermissionOptionKind.REJECT_ONCE.toV2())
+        assertEquals(PermissionOptionKind.RejectAlways, V1PermissionOptionKind.REJECT_ALWAYS.toV2())
+    }
+
+    private fun decode(json: String): PermissionOptionKind =
+        ACPJson.decodeFromString(PermissionOptionKind.serializer(), json)
+
+    private fun encode(kind: PermissionOptionKind): String =
+        ACPJson.encodeToString(PermissionOptionKind.serializer(), kind)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/PlanEntryPriorityTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/PlanEntryPriorityTest.kt
@@ -1,0 +1,89 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.PlanEntryPriority as V1PlanEntryPriority
+
+class PlanEntryPriorityTest {
+
+    // Known values
+
+    @Test
+    fun `decodes all known values`() {
+        assertEquals(PlanEntryPriority.High, decode("\"high\""))
+        assertEquals(PlanEntryPriority.Medium, decode("\"medium\""))
+        assertEquals(PlanEntryPriority.Low, decode("\"low\""))
+    }
+
+    @Test
+    fun `encodes all known values`() {
+        assertEquals("\"high\"", encode(PlanEntryPriority.High))
+        assertEquals("\"medium\"", encode(PlanEntryPriority.Medium))
+        assertEquals("\"low\"", encode(PlanEntryPriority.Low))
+    }
+
+    // Unknown values (forward compatibility)
+
+    @Test
+    fun `decodes unknown value as Unknown and round-trips byte-identically`() {
+        val priority = decode("\"critical\"")
+
+        assertIs<PlanEntryPriority.Unknown>(priority)
+        assertEquals("critical", priority.value)
+        assertEquals("\"_vendor_priority\"", encode(decode("\"_vendor_priority\"")))
+    }
+
+    // Extension factory
+
+    @Test
+    fun `extension creates Unknown for underscore-prefixed values`() {
+        assertEquals(PlanEntryPriority.extension("_vendor_priority"), PlanEntryPriority.Unknown("_vendor_priority"))
+    }
+
+    @Test
+    fun `extension rejects values without underscore prefix`() {
+        assertFailsWith<IllegalArgumentException> {
+            PlanEntryPriority.extension("vendor_priority")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts all known values to v1`() {
+        assertEquals(V1PlanEntryPriority.HIGH, PlanEntryPriority.High.toV1())
+        assertEquals(V1PlanEntryPriority.MEDIUM, PlanEntryPriority.Medium.toV1())
+        assertEquals(V1PlanEntryPriority.LOW, PlanEntryPriority.Low.toV1())
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            PlanEntryPriority.Unknown("critical").toV1()
+        }
+
+        assertEquals("v2 PlanEntryPriority variant `critical` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converts all v1 values to v2`() {
+        assertEquals(PlanEntryPriority.High, V1PlanEntryPriority.HIGH.toV2())
+        assertEquals(PlanEntryPriority.Medium, V1PlanEntryPriority.MEDIUM.toV2())
+        assertEquals(PlanEntryPriority.Low, V1PlanEntryPriority.LOW.toV2())
+    }
+
+    private fun decode(json: String): PlanEntryPriority =
+        ACPJson.decodeFromString(PlanEntryPriority.serializer(), json)
+
+    private fun encode(priority: PlanEntryPriority): String =
+        ACPJson.encodeToString(PlanEntryPriority.serializer(), priority)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/PlanEntryStatusTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/PlanEntryStatusTest.kt
@@ -1,0 +1,89 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.PlanEntryStatus as V1PlanEntryStatus
+
+class PlanEntryStatusTest {
+
+    // Known values
+
+    @Test
+    fun `decodes all known values`() {
+        assertEquals(PlanEntryStatus.Pending, decode("\"pending\""))
+        assertEquals(PlanEntryStatus.InProgress, decode("\"in_progress\""))
+        assertEquals(PlanEntryStatus.Completed, decode("\"completed\""))
+    }
+
+    @Test
+    fun `encodes all known values`() {
+        assertEquals("\"pending\"", encode(PlanEntryStatus.Pending))
+        assertEquals("\"in_progress\"", encode(PlanEntryStatus.InProgress))
+        assertEquals("\"completed\"", encode(PlanEntryStatus.Completed))
+    }
+
+    // Unknown values (forward compatibility)
+
+    @Test
+    fun `decodes unknown value as Unknown and round-trips byte-identically`() {
+        val status = decode("\"skipped\"")
+
+        assertIs<PlanEntryStatus.Unknown>(status)
+        assertEquals("skipped", status.value)
+        assertEquals("\"_vendor_status\"", encode(decode("\"_vendor_status\"")))
+    }
+
+    // Extension factory
+
+    @Test
+    fun `extension creates Unknown for underscore-prefixed values`() {
+        assertEquals(PlanEntryStatus.extension("_vendor_status"), PlanEntryStatus.Unknown("_vendor_status"))
+    }
+
+    @Test
+    fun `extension rejects values without underscore prefix`() {
+        assertFailsWith<IllegalArgumentException> {
+            PlanEntryStatus.extension("vendor_status")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts all known values to v1`() {
+        assertEquals(V1PlanEntryStatus.PENDING, PlanEntryStatus.Pending.toV1())
+        assertEquals(V1PlanEntryStatus.IN_PROGRESS, PlanEntryStatus.InProgress.toV1())
+        assertEquals(V1PlanEntryStatus.COMPLETED, PlanEntryStatus.Completed.toV1())
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            PlanEntryStatus.Unknown("skipped").toV1()
+        }
+
+        assertEquals("v2 PlanEntryStatus variant `skipped` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converts all v1 values to v2`() {
+        assertEquals(PlanEntryStatus.Pending, V1PlanEntryStatus.PENDING.toV2())
+        assertEquals(PlanEntryStatus.InProgress, V1PlanEntryStatus.IN_PROGRESS.toV2())
+        assertEquals(PlanEntryStatus.Completed, V1PlanEntryStatus.COMPLETED.toV2())
+    }
+
+    private fun decode(json: String): PlanEntryStatus =
+        ACPJson.decodeFromString(PlanEntryStatus.serializer(), json)
+
+    private fun encode(status: PlanEntryStatus): String =
+        ACPJson.encodeToString(PlanEntryStatus.serializer(), status)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/PlanRemovedTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/PlanRemovedTest.kt
@@ -1,0 +1,46 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class PlanRemovedTest {
+
+    @Test
+    fun `round-trips a removal notice`() {
+        val json = """{"planId":"p1"}"""
+
+        assertEquals(PlanRemoved(planId = PlanId("p1")), decode(json))
+        assertEquals(json, encode(PlanRemoved(planId = PlanId("p1"))))
+    }
+
+    @Test
+    fun `round-trips meta`() {
+        val removed = PlanRemoved(
+            planId = PlanId("p1"),
+            _meta = buildJsonObject { put("reason", JsonPrimitive("superseded")) },
+        )
+        val json = """{"planId":"p1","_meta":{"reason":"superseded"}}"""
+
+        assertEquals(json, encode(removed))
+        assertEquals(removed, decode(json))
+    }
+
+    @Test
+    fun `requires a plan id`() {
+        assertFailsWith<SerializationException> { decode("{}") }
+    }
+
+    private fun decode(json: String): PlanRemoved =
+        ACPJson.decodeFromString(PlanRemoved.serializer(), json)
+
+    private fun encode(removed: PlanRemoved): String =
+        ACPJson.encodeToString(PlanRemoved.serializer(), removed)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/PlanUpdateTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/PlanUpdateTest.kt
@@ -1,0 +1,127 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+class PlanUpdateTest {
+
+    private val entry = PlanEntry(
+        content = "Port the plan payloads",
+        priority = PlanEntryPriority.High,
+        status = PlanEntryStatus.InProgress,
+    )
+
+    // Known content types
+
+    @Test
+    fun `decodes an itemized plan`() {
+        assertEquals(
+            PlanUpdate(plan = PlanUpdateContent.Items(planId = PlanId("main"), entries = listOf(entry))),
+            decode(
+                """{"plan":{"type":"items","planId":"main","entries":[""" +
+                    """{"content":"Port the plan payloads","priority":"high","status":"in_progress"}]}}""",
+            ),
+        )
+    }
+
+    @Test
+    fun `encodes an itemized plan with a leading discriminator`() {
+        assertEquals(
+            """{"plan":{"type":"items","planId":"main","entries":[""" +
+                """{"content":"Port the plan payloads","priority":"high","status":"in_progress"}]}}""",
+            encode(PlanUpdate(plan = PlanUpdateContent.Items(planId = PlanId("main"), entries = listOf(entry)))),
+        )
+    }
+
+    @Test
+    fun `round-trips the unstable file and markdown content types`() {
+        val file = """{"plan":{"type":"file","planId":"p1","uri":"file:///tmp/plan.md"}}"""
+        val markdown = """{"plan":{"type":"markdown","planId":"p1","content":"# Plan"}}"""
+
+        assertEquals(
+            PlanUpdate(plan = PlanUpdateContent.File(planId = PlanId("p1"), uri = "file:///tmp/plan.md")),
+            decode(file),
+        )
+        assertEquals(file, encode(decode(file)))
+        assertEquals(
+            PlanUpdate(plan = PlanUpdateContent.Markdown(planId = PlanId("p1"), content = "# Plan")),
+            decode(markdown),
+        )
+        assertEquals(markdown, encode(decode(markdown)))
+    }
+
+    @Test
+    fun `every content variant exposes its plan id`() {
+        val contents = listOf(
+            PlanUpdateContent.Items(planId = PlanId("p1"), entries = emptyList()),
+            PlanUpdateContent.File(planId = PlanId("p1"), uri = "file:///plan.md"),
+            PlanUpdateContent.Markdown(planId = PlanId("p1"), content = "# Plan"),
+        )
+
+        contents.forEach { assertEquals(PlanId("p1"), it.planId) }
+    }
+
+    @Test
+    fun `preserves an unknown plan entry priority and status`() {
+        val decoded = decode(
+            """{"plan":{"type":"items","planId":"main","entries":[""" +
+                """{"content":"x","priority":"_urgent","status":"_blocked"}]}}""",
+        )
+
+        val items = decoded.plan
+        assertIs<PlanUpdateContent.Items>(items)
+        assertEquals(PlanEntryPriority.Unknown("_urgent"), items.entries.single().priority)
+        assertEquals(PlanEntryStatus.Unknown("_blocked"), items.entries.single().status)
+    }
+
+    // Open union behaviour
+
+    @Test
+    fun `preserves unknown plan content byte-identically and keeps the plan id`() {
+        val json = """{"plan":{"type":"_vendor_graph","planId":"p1","nodes":[1,2]}}"""
+
+        val decoded = decode(json)
+        val unknown = decoded.plan
+        assertIs<PlanUpdateContent.Unknown>(unknown)
+        assertEquals("_vendor_graph", unknown.type)
+        assertEquals(PlanId("p1"), unknown.planId)
+        assertEquals(json, encode(decoded))
+    }
+
+    @Test
+    fun `unknown plan content without a plan id fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"plan":{"type":"_vendor_graph","nodes":[1,2]}}""")
+        }
+    }
+
+    @Test
+    fun `unknown plan content with a non-string plan id fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"plan":{"type":"_vendor_graph","planId":{"nested":true}}}""")
+        }
+    }
+
+    @Test
+    fun `missing type discriminator fails`() {
+        assertFailsWith<SerializationException> { decode("""{"plan":{"planId":"p1","entries":[]}}""") }
+    }
+
+    @Test
+    fun `known content type with a malformed payload fails instead of falling back`() {
+        assertFailsWith<SerializationException> { decode("""{"plan":{"type":"items","entries":[]}}""") }
+    }
+
+    private fun decode(json: String): PlanUpdate =
+        ACPJson.decodeFromString(PlanUpdate.serializer(), json)
+
+    private fun encode(update: PlanUpdate): String =
+        ACPJson.encodeToString(PlanUpdate.serializer(), update)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/RequestPermissionOutcomeTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/RequestPermissionOutcomeTest.kt
@@ -1,0 +1,114 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.PermissionOptionId
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.RequestPermissionOutcome as V1RequestPermissionOutcome
+
+class RequestPermissionOutcomeTest {
+
+    // Known variants
+
+    @Test
+    fun `decodes known variants`() {
+        assertEquals(RequestPermissionOutcome.Cancelled, decode("""{"outcome":"cancelled"}"""))
+        assertEquals(
+            RequestPermissionOutcome.Selected(optionId = PermissionOptionId("allow-once")),
+            decode("""{"outcome":"selected","optionId":"allow-once"}"""),
+        )
+    }
+
+    @Test
+    fun `encodes known variants with leading discriminator`() {
+        assertEquals("""{"outcome":"cancelled"}""", encode(RequestPermissionOutcome.Cancelled))
+        assertEquals(
+            """{"outcome":"selected","optionId":"allow-once"}""",
+            encode(RequestPermissionOutcome.Selected(optionId = PermissionOptionId("allow-once"))),
+        )
+    }
+
+    // Unknown discriminators (forward compatibility)
+
+    @Test
+    fun `decodes unknown outcome as Unknown preserving the full payload`() {
+        val json = """{"outcome":"deferred","until":"2027-01-01"}"""
+
+        val outcome = decode(json)
+
+        assertIs<RequestPermissionOutcome.Unknown>(outcome)
+        assertEquals("deferred", outcome.outcome)
+        assertEquals(json, encode(outcome))
+    }
+
+    @Test
+    fun `underscore-prefixed extension outcome round-trips byte-identically`() {
+        val json = """{"outcome":"_vendor_policy","rule":42}"""
+
+        assertEquals(json, encode(decode(json)))
+    }
+
+    // Strictness
+
+    @Test
+    fun `missing discriminator fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"optionId":"allow-once"}""")
+        }
+    }
+
+    @Test
+    fun `known discriminator with malformed payload fails instead of falling back`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"outcome":"selected"}""")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts known variants to v1`() {
+        assertEquals(V1RequestPermissionOutcome.Cancelled, RequestPermissionOutcome.Cancelled.toV1())
+        assertEquals(
+            V1RequestPermissionOutcome.Selected(optionId = PermissionOptionId("allow-once")),
+            RequestPermissionOutcome.Selected(optionId = PermissionOptionId("allow-once")).toV1(),
+        )
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            RequestPermissionOutcome.Unknown("deferred", buildJsonObject {}).toV1()
+        }
+
+        assertEquals(
+            "v2 RequestPermissionOutcome variant `deferred` cannot be represented in v1",
+            exception.message,
+        )
+    }
+
+    @Test
+    fun `converts all v1 values to v2`() {
+        assertEquals(RequestPermissionOutcome.Cancelled, V1RequestPermissionOutcome.Cancelled.toV2())
+        assertEquals(
+            RequestPermissionOutcome.Selected(optionId = PermissionOptionId("allow-once")),
+            V1RequestPermissionOutcome.Selected(optionId = PermissionOptionId("allow-once")).toV2(),
+        )
+    }
+
+    private fun decode(json: String): RequestPermissionOutcome =
+        ACPJson.decodeFromString(RequestPermissionOutcome.serializer(), json)
+
+    private fun encode(outcome: RequestPermissionOutcome): String =
+        ACPJson.encodeToString(RequestPermissionOutcome.serializer(), outcome)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/RoleTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/RoleTest.kt
@@ -1,0 +1,85 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.Role as V1Role
+
+class RoleTest {
+
+    // Known values
+
+    @Test
+    fun `decodes all known values`() {
+        assertEquals(Role.Assistant, decode("\"assistant\""))
+        assertEquals(Role.User, decode("\"user\""))
+    }
+
+    @Test
+    fun `encodes all known values`() {
+        assertEquals("\"assistant\"", encode(Role.Assistant))
+        assertEquals("\"user\"", encode(Role.User))
+    }
+
+    // Unknown values (forward compatibility)
+
+    @Test
+    fun `decodes unknown value as Unknown and round-trips byte-identically`() {
+        val role = decode("\"system\"")
+
+        assertIs<Role.Unknown>(role)
+        assertEquals("system", role.value)
+        assertEquals("\"_vendor_role\"", encode(decode("\"_vendor_role\"")))
+    }
+
+    // Extension factory
+
+    @Test
+    fun `extension creates Unknown for underscore-prefixed values`() {
+        assertEquals(Role.extension("_vendor_role"), Role.Unknown("_vendor_role"))
+    }
+
+    @Test
+    fun `extension rejects values without underscore prefix`() {
+        assertFailsWith<IllegalArgumentException> {
+            Role.extension("vendor_role")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts all known values to v1`() {
+        assertEquals(V1Role.ASSISTANT, Role.Assistant.toV1())
+        assertEquals(V1Role.USER, Role.User.toV1())
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            Role.Unknown("system").toV1()
+        }
+
+        assertEquals("v2 Role variant `system` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converts all v1 values to v2`() {
+        assertEquals(Role.Assistant, V1Role.ASSISTANT.toV2())
+        assertEquals(Role.User, V1Role.USER.toV2())
+    }
+
+    private fun decode(json: String): Role =
+        ACPJson.decodeFromString(Role.serializer(), json)
+
+    private fun encode(role: Role): String =
+        ACPJson.encodeToString(Role.serializer(), role)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/SessionConfigOptionCategoryTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/SessionConfigOptionCategoryTest.kt
@@ -1,0 +1,102 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.SessionConfigOptionCategory as V1SessionConfigOptionCategory
+
+class SessionConfigOptionCategoryTest {
+
+    // Known values
+
+    @Test
+    fun `decodes all known values`() {
+        assertEquals(SessionConfigOptionCategory.Mode, decode("\"mode\""))
+        assertEquals(SessionConfigOptionCategory.Model, decode("\"model\""))
+        assertEquals(SessionConfigOptionCategory.ModelConfig, decode("\"model_config\""))
+        assertEquals(SessionConfigOptionCategory.ThoughtLevel, decode("\"thought_level\""))
+    }
+
+    @Test
+    fun `encodes all known values`() {
+        assertEquals("\"mode\"", encode(SessionConfigOptionCategory.Mode))
+        assertEquals("\"model\"", encode(SessionConfigOptionCategory.Model))
+        assertEquals("\"model_config\"", encode(SessionConfigOptionCategory.ModelConfig))
+        assertEquals("\"thought_level\"", encode(SessionConfigOptionCategory.ThoughtLevel))
+    }
+
+    // Unknown values (forward compatibility)
+
+    @Test
+    fun `decodes unknown value as Unknown and round-trips byte-identically`() {
+        val category = decode("\"toolchain\"")
+
+        assertIs<SessionConfigOptionCategory.Unknown>(category)
+        assertEquals("toolchain", category.value)
+        assertEquals("\"_vendor_category\"", encode(decode("\"_vendor_category\"")))
+    }
+
+    // Extension factory
+
+    @Test
+    fun `extension creates Unknown for underscore-prefixed values`() {
+        assertEquals(
+            SessionConfigOptionCategory.extension("_vendor_category"),
+            SessionConfigOptionCategory.Unknown("_vendor_category"),
+        )
+    }
+
+    @Test
+    fun `extension rejects values without underscore prefix`() {
+        assertFailsWith<IllegalArgumentException> {
+            SessionConfigOptionCategory.extension("vendor_category")
+        }
+    }
+
+    // v2 <-> v1 conversion (total both ways: v1 is an open string wrapper)
+
+    @Test
+    fun `converts all known values to v1`() {
+        assertEquals(SessionConfigOptionCategory.Mode.toV1(), V1SessionConfigOptionCategory.MODE)
+        assertEquals(SessionConfigOptionCategory.Model.toV1(), V1SessionConfigOptionCategory.MODEL)
+        assertEquals(SessionConfigOptionCategory.ModelConfig.toV1(), V1SessionConfigOptionCategory("model_config"))
+        assertEquals(SessionConfigOptionCategory.ThoughtLevel.toV1(), V1SessionConfigOptionCategory.THOUGHT_LEVEL)
+    }
+
+    @Test
+    fun `converts Unknown to v1 without data loss`() {
+        assertEquals(
+            V1SessionConfigOptionCategory("toolchain"),
+            SessionConfigOptionCategory.Unknown("toolchain").toV1(),
+        )
+    }
+
+    @Test
+    fun `converts all well-known v1 values to v2`() {
+        assertEquals(SessionConfigOptionCategory.Mode, V1SessionConfigOptionCategory.MODE.toV2())
+        assertEquals(SessionConfigOptionCategory.Model, V1SessionConfigOptionCategory.MODEL.toV2())
+        assertEquals(SessionConfigOptionCategory.ModelConfig, V1SessionConfigOptionCategory("model_config").toV2())
+        assertEquals(SessionConfigOptionCategory.ThoughtLevel, V1SessionConfigOptionCategory.THOUGHT_LEVEL.toV2())
+    }
+
+    @Test
+    fun `converts custom v1 value to v2 Unknown`() {
+        assertEquals(
+            SessionConfigOptionCategory.Unknown("toolchain"),
+            V1SessionConfigOptionCategory("toolchain").toV2(),
+        )
+    }
+
+    private fun decode(json: String): SessionConfigOptionCategory =
+        ACPJson.decodeFromString(SessionConfigOptionCategory.serializer(), json)
+
+    private fun encode(category: SessionConfigOptionCategory): String =
+        ACPJson.encodeToString(SessionConfigOptionCategory.serializer(), category)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/SessionConfigOptionTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/SessionConfigOptionTest.kt
@@ -1,0 +1,204 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.SessionConfigGroupId
+import com.agentclientprotocol.model.SessionConfigId
+import com.agentclientprotocol.model.SessionConfigSelectOption
+import com.agentclientprotocol.model.SessionConfigValueId
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.SessionConfigOption as V1SessionConfigOption
+import com.agentclientprotocol.model.SessionConfigSelectGroup as V1SessionConfigSelectGroup
+import com.agentclientprotocol.model.SessionConfigSelectOptions as V1SessionConfigSelectOptions
+
+class SessionConfigOptionTest {
+
+    private val fastOption = SessionConfigSelectOption(value = SessionConfigValueId("fast"), name = "Fast")
+    private val selectOption = SessionConfigOption(
+        configId = SessionConfigId("model"),
+        name = "Model",
+        category = SessionConfigOptionCategory.Model,
+        kind = SessionConfigKind.Select(
+            currentValue = SessionConfigValueId("fast"),
+            options = SessionConfigSelectOptions.Ungrouped(listOf(fastOption)),
+        ),
+    )
+
+    // Known kinds
+
+    @Test
+    fun `decodes select and boolean kinds`() {
+        assertEquals(
+            selectOption,
+            decode(
+                """{"type":"select","configId":"model","name":"Model","category":"model",""" +
+                    """"currentValue":"fast","options":[{"value":"fast","name":"Fast"}]}""",
+            ),
+        )
+        assertEquals(
+            SessionConfigOption(
+                configId = SessionConfigId("verbose"),
+                name = "Verbose",
+                kind = SessionConfigKind.Boolean(currentValue = true),
+            ),
+            decode("""{"type":"boolean","configId":"verbose","name":"Verbose","currentValue":true}"""),
+        )
+    }
+
+    @Test
+    fun `encodes with flattened kind and leading discriminator`() {
+        assertEquals(
+            """{"type":"select","configId":"model","name":"Model","category":"model",""" +
+                """"currentValue":"fast","options":[{"value":"fast","name":"Fast"}]}""",
+            encode(selectOption),
+        )
+    }
+
+    @Test
+    fun `grouped options round-trip and are detected by groupId`() {
+        val option = SessionConfigOption(
+            configId = SessionConfigId("model"),
+            name = "Model",
+            kind = SessionConfigKind.Select(
+                currentValue = SessionConfigValueId("fast"),
+                options = SessionConfigSelectOptions.Grouped(
+                    listOf(
+                        SessionConfigSelectGroup(
+                            groupId = SessionConfigGroupId("speed"),
+                            name = "Speed",
+                            options = listOf(fastOption),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        assertEquals(option, decode(encode(option)))
+    }
+
+    // Unknown kinds (forward compatibility)
+
+    @Test
+    fun `decodes unknown kind preserving its extra fields`() {
+        val option = decode(
+            """{"type":"slider","configId":"temp","name":"Temperature","min":0,"max":2,"currentValue":0.7}""",
+        )
+
+        val kind = option.kind
+        assertIs<SessionConfigKind.Unknown>(kind)
+        assertEquals("slider", kind.type)
+        assertEquals(SessionConfigId("temp"), option.configId)
+        assertEquals(option, decode(encode(option)))
+    }
+
+    // Strictness
+
+    @Test
+    fun `missing discriminator fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"configId":"model","name":"Model","currentValue":"fast"}""")
+        }
+    }
+
+    @Test
+    fun `select without options fails instead of falling back`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"type":"select","configId":"model","name":"Model","currentValue":"fast"}""")
+        }
+    }
+
+    @Test
+    fun `unknown kind still requires configId and name`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"type":"slider","name":"Temperature"}""")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts select to v1 mapping configId to id`() {
+        assertEquals(
+            V1SessionConfigOption.Select(
+                id = SessionConfigId("model"),
+                name = "Model",
+                category = com.agentclientprotocol.model.SessionConfigOptionCategory.MODEL,
+                currentValue = SessionConfigValueId("fast"),
+                options = V1SessionConfigSelectOptions.Flat(listOf(fastOption)),
+            ),
+            selectOption.toV1(),
+        )
+    }
+
+    @Test
+    fun `converting unknown kind to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            SessionConfigOption(
+                configId = SessionConfigId("temp"),
+                name = "Temperature",
+                kind = SessionConfigKind.Unknown("slider", kotlinx.serialization.json.buildJsonObject {}),
+            ).toV1()
+        }
+
+        assertEquals("v2 SessionConfigKind variant `slider` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converts v1 options to v2 mapping group to groupId`() {
+        val v2 = V1SessionConfigOption.Select(
+            id = SessionConfigId("model"),
+            name = "Model",
+            currentValue = SessionConfigValueId("fast"),
+            options = V1SessionConfigSelectOptions.Grouped(
+                listOf(V1SessionConfigSelectGroup(group = SessionConfigGroupId("speed"), options = listOf(fastOption))),
+            ),
+        ).toV2()
+
+        assertEquals(
+            SessionConfigKind.Select(
+                currentValue = SessionConfigValueId("fast"),
+                options = SessionConfigSelectOptions.Grouped(
+                    listOf(
+                        SessionConfigSelectGroup(
+                            groupId = SessionConfigGroupId("speed"),
+                            name = "",
+                            options = listOf(fastOption),
+                        ),
+                    ),
+                ),
+            ),
+            v2.kind,
+        )
+    }
+
+    @Test
+    fun `converts v1 boolean option to v2`() {
+        assertEquals(
+            SessionConfigOption(
+                configId = SessionConfigId("verbose"),
+                name = "Verbose",
+                kind = SessionConfigKind.Boolean(currentValue = true),
+            ),
+            V1SessionConfigOption.BooleanOption(
+                id = SessionConfigId("verbose"),
+                name = "Verbose",
+                currentValue = true,
+            ).toV2(),
+        )
+    }
+
+    private fun decode(json: String): SessionConfigOption =
+        ACPJson.decodeFromString(SessionConfigOption.serializer(), json)
+
+    private fun encode(option: SessionConfigOption): String =
+        ACPJson.encodeToString(SessionConfigOption.serializer(), option)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/SessionConfigOptionValueTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/SessionConfigOptionValueTest.kt
@@ -1,0 +1,131 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.SessionConfigValueId
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.SessionConfigOptionValue as V1SessionConfigOptionValue
+
+class SessionConfigOptionValueTest {
+
+    // Known variants
+
+    @Test
+    fun `decodes tagged id and boolean values`() {
+        assertEquals(
+            SessionConfigOptionValue.Id(SessionConfigValueId("fast")),
+            decode("""{"type":"id","value":"fast"}"""),
+        )
+        assertEquals(
+            SessionConfigOptionValue.Boolean(true),
+            decode("""{"type":"boolean","value":true}"""),
+        )
+    }
+
+    @Test
+    fun `encodes known variants with leading discriminator`() {
+        assertEquals("""{"type":"id","value":"fast"}""", encode(SessionConfigOptionValue.Id(SessionConfigValueId("fast"))))
+        assertEquals("""{"type":"boolean","value":true}""", encode(SessionConfigOptionValue.Boolean(true)))
+    }
+
+    // Unknown discriminators (forward compatibility)
+
+    @Test
+    fun `decodes unknown value type as Unknown preserving the full payload`() {
+        val json = """{"type":"number","value":0.7,"scale":"linear"}"""
+
+        val value = decode(json)
+
+        assertIs<SessionConfigOptionValue.Unknown>(value)
+        assertEquals("number", value.type)
+        assertEquals(JsonPrimitive(0.7), value.value)
+        assertEquals(json, encode(value))
+    }
+
+    @Test
+    fun `unknown value type without a value payload fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"type":"number","scale":"linear"}""")
+        }
+    }
+
+    // Strictness
+
+    @Test
+    fun `missing discriminator fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"value":"fast"}""")
+        }
+    }
+
+    @Test
+    fun `known discriminator with malformed payload fails instead of falling back`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"type":"id"}""")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts known variants to v1 raw values`() {
+        assertEquals(
+            V1SessionConfigOptionValue.StringValue("fast"),
+            SessionConfigOptionValue.Id(SessionConfigValueId("fast")).toV1(),
+        )
+        assertEquals(
+            V1SessionConfigOptionValue.BoolValue(true),
+            SessionConfigOptionValue.Boolean(true).toV1(),
+        )
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            SessionConfigOptionValue.Unknown(
+                type = "number",
+                value = JsonPrimitive(0.7),
+                rawJson = kotlinx.serialization.json.buildJsonObject {},
+            ).toV1()
+        }
+
+        assertEquals("v2 SessionConfigOptionValue variant `number` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converts v1 raw values to v2 tagged values`() {
+        assertEquals(
+            SessionConfigOptionValue.Id(SessionConfigValueId("fast")),
+            V1SessionConfigOptionValue.StringValue("fast").toV2(),
+        )
+        assertEquals(
+            SessionConfigOptionValue.Boolean(false),
+            V1SessionConfigOptionValue.BoolValue(false).toV2(),
+        )
+    }
+
+    @Test
+    fun `converting v1 UnknownValue to v2 fails instead of fabricating a payload`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            V1SessionConfigOptionValue.UnknownValue(JsonPrimitive(42)).toV2()
+        }
+
+        assertEquals("v1 SessionConfigOptionValue variant `UnknownValue` cannot be represented in v2", exception.message)
+    }
+
+    private fun decode(json: String): SessionConfigOptionValue =
+        ACPJson.decodeFromString(SessionConfigOptionValue.serializer(), json)
+
+    private fun encode(value: SessionConfigOptionValue): String =
+        ACPJson.encodeToString(SessionConfigOptionValue.serializer(), value)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/SessionInfoUpdateTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/SessionInfoUpdateTest.kt
@@ -1,0 +1,86 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SessionInfoUpdateTest {
+
+    // Encoding: Undefined is omitted, Null is an explicit null, Value is encoded
+
+    @Test
+    fun `encodes an empty update as an empty object`() {
+        assertEquals("{}", encode(SessionInfoUpdate()))
+    }
+
+    @Test
+    fun `encodes only set fields`() {
+        assertEquals(
+            """{"title":"Refactor the parser"}""",
+            encode(SessionInfoUpdate(title = MaybeUndefined.Value("Refactor the parser"))),
+        )
+    }
+
+    @Test
+    fun `encodes an explicit null for a cleared title`() {
+        assertEquals(
+            """{"title":null,"updatedAt":"2026-07-24T10:00:00Z"}""",
+            encode(
+                SessionInfoUpdate(
+                    title = MaybeUndefined.Null,
+                    updatedAt = MaybeUndefined.Value("2026-07-24T10:00:00Z"),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `encodes an explicit null for cleared meta`() {
+        assertEquals("""{"_meta":null}""", encode(SessionInfoUpdate(_meta = MaybeUndefined.Null)))
+    }
+
+    // Decoding: absent, null, and value are three distinct states
+
+    @Test
+    fun `decodes omitted null and value states distinctly`() {
+        val update = decode("""{"title":null,"updatedAt":"2026-07-24T10:00:00Z"}""")
+
+        assertEquals(MaybeUndefined.Null, update.title)
+        assertEquals(MaybeUndefined.Value("2026-07-24T10:00:00Z"), update.updatedAt)
+        assertEquals(MaybeUndefined.Undefined, update._meta)
+    }
+
+    @Test
+    fun `decodes an empty object as an all-Undefined update`() {
+        assertEquals(SessionInfoUpdate(), decode("{}"))
+    }
+
+    @Test
+    fun `round-trips meta`() {
+        val update = SessionInfoUpdate(
+            _meta = MaybeUndefined.Value(buildJsonObject { put("pinned", JsonPrimitive(true)) }),
+        )
+        val json = """{"_meta":{"pinned":true}}"""
+
+        assertEquals(json, encode(update))
+        assertEquals(update, decode(json))
+    }
+
+    @Test
+    fun `degrades a malformed title to Undefined`() {
+        // DefaultOnError parity: a structured value where a string is expected is dropped
+        // rather than failing the whole update.
+        assertEquals(MaybeUndefined.Undefined, decode("""{"title":{"nested":true}}""").title)
+    }
+
+    private fun decode(json: String): SessionInfoUpdate =
+        ACPJson.decodeFromString(SessionInfoUpdate.serializer(), json)
+
+    private fun encode(update: SessionInfoUpdate): String =
+        ACPJson.encodeToString(SessionInfoUpdate.serializer(), update)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/SessionUpdateConversionTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/SessionUpdateConversionTest.kt
@@ -1,0 +1,398 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.MessageId
+import com.agentclientprotocol.model.SessionModeId
+import com.agentclientprotocol.model.ToolCallId
+import com.agentclientprotocol.model.v2.conversion.LEGACY_V1_PLAN_ID
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import com.agentclientprotocol.model.ContentBlock as V1ContentBlock
+import com.agentclientprotocol.model.PlanEntry as V1PlanEntry
+import com.agentclientprotocol.model.PlanEntryPriority as V1PlanEntryPriority
+import com.agentclientprotocol.model.PlanEntryStatus as V1PlanEntryStatus
+import com.agentclientprotocol.model.PlanVariant as V1PlanVariant
+import com.agentclientprotocol.model.SessionUpdate as V1SessionUpdate
+import com.agentclientprotocol.model.ToolCallStatus as V1ToolCallStatus
+import com.agentclientprotocol.model.ToolKind as V1ToolKind
+
+class SessionUpdateConversionTest {
+
+    // Chunks
+
+    @Test
+    fun `converts content chunks in both directions`() {
+        val v2 = SessionUpdate.AgentMessageChunk(
+            ContentChunk(messageId = MessageId("msg_1"), content = ContentBlock.Text(text = "hi")),
+        )
+        val v1 = V1SessionUpdate.AgentMessageChunk(
+            content = V1ContentBlock.Text(text = "hi"),
+            messageId = MessageId("msg_1"),
+        )
+
+        assertEquals(listOf(v1), v2.toV1())
+        assertEquals(v2, v1.toV2())
+    }
+
+    @Test
+    fun `converting a v1 chunk without a message id fails because v2 requires one`() {
+        val v1 = V1SessionUpdate.UserMessageChunk(content = V1ContentBlock.Text(text = "hi"))
+
+        assertFailsWith<ProtocolConversionException> { v1.toV2() }
+    }
+
+    // Message upserts explode into one v1 chunk per content block
+
+    @Test
+    fun `a message upsert becomes one v1 chunk per content block`() {
+        val update = SessionUpdate.AgentMessage(
+            AgentMessage(
+                messageId = MessageId("msg_1"),
+                content = MaybeUndefined.Value(
+                    listOf(ContentBlock.Text(text = "one"), ContentBlock.Text(text = "two")),
+                ),
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                V1SessionUpdate.AgentMessageChunk(V1ContentBlock.Text(text = "one"), MessageId("msg_1")),
+                V1SessionUpdate.AgentMessageChunk(V1ContentBlock.Text(text = "two"), MessageId("msg_1")),
+            ),
+            update.toV1(),
+        )
+    }
+
+    @Test
+    fun `a message upsert without usable content cannot become v1 chunks`() {
+        val cases = listOf<MaybeUndefined<List<ContentBlock>>>(
+            MaybeUndefined.Undefined,
+            MaybeUndefined.Null,
+            MaybeUndefined.Value(emptyList()),
+        )
+
+        cases.forEach { content ->
+            val update = SessionUpdate.UserMessage(
+                UserMessage(messageId = MessageId("msg_1"), content = content),
+            )
+            assertFailsWith<ProtocolConversionException>("content=$content") { update.toV1() }
+        }
+    }
+
+    @Test
+    fun `a message upsert with cleared meta cannot become v1 chunks`() {
+        val update = SessionUpdate.AgentThought(
+            AgentThought(
+                messageId = MessageId("msg_1"),
+                content = MaybeUndefined.Value(listOf(ContentBlock.Text(text = "hm"))),
+                _meta = MaybeUndefined.Null,
+            ),
+        )
+
+        assertFailsWith<ProtocolConversionException> { update.toV1() }
+    }
+
+    // Variants with no v1 representation
+
+    @Test
+    fun `state updates and tool call content chunks have no v1 form`() {
+        assertFailsWith<ProtocolConversionException> {
+            SessionUpdate.StateUpdate(StateUpdate.Idle()).toV1()
+        }
+        assertFailsWith<ProtocolConversionException> {
+            SessionUpdate.ToolCallContentChunk(
+                ToolCallContentChunk(
+                    toolCallId = ToolCallId("tc_1"),
+                    content = ToolCallContent.Content(content = ContentBlock.Text(text = "out")),
+                ),
+            ).toV1()
+        }
+    }
+
+    @Test
+    fun `an unknown v2 update has no v1 form`() {
+        assertFailsWith<ProtocolConversionException> {
+            SessionUpdate.Unknown("_vendor", buildJsonObject { put("sessionUpdate", JsonPrimitive("_vendor")) })
+                .toV1()
+        }
+    }
+
+    @Test
+    fun `an unknown v1 update crosses to v2 unchanged`() {
+        val rawJson = buildJsonObject { put("sessionUpdate", JsonPrimitive("_vendor")) }
+        val v1 = V1SessionUpdate.UnknownSessionUpdate(sessionUpdateType = "_vendor", rawJson = rawJson)
+
+        assertEquals(SessionUpdate.Unknown("_vendor", rawJson), v1.toV2())
+    }
+
+    @Test
+    fun `current mode update was removed in v2`() {
+        assertFailsWith<ProtocolConversionException> {
+            V1SessionUpdate.CurrentModeUpdate(currentModeId = SessionModeId("ask")).toV2()
+        }
+    }
+
+    // Tool calls: v1's two variants collapse into one v2 upsert
+
+    @Test
+    fun `a v1 tool call becomes a v2 upsert leaving defaults unset`() {
+        val v1 = V1SessionUpdate.ToolCall(
+            toolCallId = ToolCallId("tc_1"),
+            title = "Read file",
+            kind = V1ToolKind.OTHER,
+            status = V1ToolCallStatus.PENDING,
+        )
+
+        assertEquals(
+            SessionUpdate.ToolCallUpdate(
+                ToolCallUpdate(toolCallId = ToolCallId("tc_1"), title = MaybeUndefined.Value("Read file")),
+            ),
+            (v1 as V1SessionUpdate).toV2(),
+        )
+    }
+
+    @Test
+    fun `a v1 tool call carries over non-default kind and status`() {
+        val v1 = V1SessionUpdate.ToolCall(
+            toolCallId = ToolCallId("tc_1"),
+            title = "Read file",
+            kind = V1ToolKind.READ,
+            status = V1ToolCallStatus.IN_PROGRESS,
+        )
+
+        val v2 = assertIs<SessionUpdate.ToolCallUpdate>((v1 as V1SessionUpdate).toV2()).update
+        assertEquals(MaybeUndefined.Value(ToolKind.Read), v2.kind)
+        assertEquals(MaybeUndefined.Value(ToolCallStatus.InProgress), v2.status)
+    }
+
+    @Test
+    fun `a v2 tool call upsert collapses patch states for v1`() {
+        val update = SessionUpdate.ToolCallUpdate(
+            ToolCallUpdate(
+                toolCallId = ToolCallId("tc_1"),
+                title = MaybeUndefined.Value("Read file"),
+                status = MaybeUndefined.Null,
+                content = MaybeUndefined.Null,
+            ),
+        )
+
+        val v1 = assertIs<V1SessionUpdate.ToolCallUpdate>(update.toV1().single())
+        assertEquals("Read file", v1.title)
+        // A cleared scalar becomes unset; a cleared collection becomes empty, which is how
+        // v1 says "no content".
+        assertNull(v1.status)
+        assertEquals(emptyList(), v1.content)
+        assertNull(v1.locations)
+    }
+
+    @Test
+    fun `an unknown tool kind is dropped rather than failing the update`() {
+        val update = SessionUpdate.ToolCallUpdate(
+            ToolCallUpdate(
+                toolCallId = ToolCallId("tc_1"),
+                kind = MaybeUndefined.Value(ToolKind.Unknown("_vendor_kind")),
+                title = MaybeUndefined.Value("Read file"),
+            ),
+        )
+
+        val v1 = assertIs<V1SessionUpdate.ToolCallUpdate>(update.toV1().single())
+        assertNull(v1.kind)
+        assertEquals("Read file", v1.title)
+    }
+
+    @Test
+    fun `a cleared tool call meta cannot be represented in v1`() {
+        val update = SessionUpdate.ToolCallUpdate(
+            ToolCallUpdate(toolCallId = ToolCallId("tc_1"), _meta = MaybeUndefined.Null),
+        )
+
+        assertFailsWith<ProtocolConversionException> { update.toV1() }
+    }
+
+    // Plans
+
+    @Test
+    fun `a v1 plan becomes a v2 plan update under the legacy plan id`() {
+        val v1 = V1SessionUpdate.PlanUpdate(
+            entries = listOf(
+                V1PlanEntry("Do it", V1PlanEntryPriority.HIGH, V1PlanEntryStatus.PENDING),
+            ),
+        )
+
+        assertEquals(
+            SessionUpdate.PlanUpdate(
+                PlanUpdate(
+                    plan = PlanUpdateContent.Items(
+                        planId = LEGACY_V1_PLAN_ID,
+                        entries = listOf(
+                            PlanEntry("Do it", PlanEntryPriority.High, PlanEntryStatus.Pending),
+                        ),
+                    ),
+                ),
+            ),
+            (v1 as V1SessionUpdate).toV2(),
+        )
+    }
+
+    @Test
+    fun `itemized plans convert down to v1's plan update`() {
+        val update = SessionUpdate.PlanUpdate(
+            PlanUpdate(
+                plan = PlanUpdateContent.Items(
+                    planId = PlanId("p1"),
+                    entries = listOf(PlanEntry("Do it", PlanEntryPriority.Low, PlanEntryStatus.Completed)),
+                ),
+            ),
+        )
+
+        assertEquals(
+            V1SessionUpdate.PlanUpdate(
+                entries = listOf(V1PlanEntry("Do it", V1PlanEntryPriority.LOW, V1PlanEntryStatus.COMPLETED)),
+            ),
+            update.toV1().single(),
+        )
+    }
+
+    @Test
+    fun `file and markdown plans convert down to v1's plan variant which keeps the id`() {
+        val file = SessionUpdate.PlanUpdate(
+            PlanUpdate(plan = PlanUpdateContent.File(planId = PlanId("p1"), uri = "file:///plan.md")),
+        )
+        val markdown = SessionUpdate.PlanUpdate(
+            PlanUpdate(plan = PlanUpdateContent.Markdown(planId = PlanId("p1"), content = "# Plan")),
+        )
+
+        assertEquals(
+            V1SessionUpdate.PlanUpdateV2(V1PlanVariant.File(id = "p1", uri = "file:///plan.md")),
+            file.toV1().single(),
+        )
+        assertEquals(
+            V1SessionUpdate.PlanUpdateV2(V1PlanVariant.Markdown(id = "p1", content = "# Plan")),
+            markdown.toV1().single(),
+        )
+        // and back
+        assertEquals(file, (file.toV1().single() as V1SessionUpdate.PlanUpdateV2).toV2().let(SessionUpdate::PlanUpdate))
+    }
+
+    @Test
+    fun `an unknown plan content type has no v1 form`() {
+        val update = SessionUpdate.PlanUpdate(
+            PlanUpdate(
+                plan = PlanUpdateContent.Unknown(
+                    type = "_vendor",
+                    planId = PlanId("p1"),
+                    rawJson = buildJsonObject { put("planId", JsonPrimitive("p1")) },
+                ),
+            ),
+        )
+
+        assertFailsWith<ProtocolConversionException> { update.toV1() }
+    }
+
+    @Test
+    fun `plan removal round-trips through v1's differently named id field`() {
+        val v2 = SessionUpdate.PlanRemoved(PlanRemoved(planId = PlanId("p1")))
+
+        assertEquals(V1SessionUpdate.PlanRemoved(id = "p1"), v2.toV1().single())
+        assertEquals(v2, V1SessionUpdate.PlanRemoved(id = "p1").toV2().let(SessionUpdate::PlanRemoved))
+    }
+
+    // Remaining payloads
+
+    @Test
+    fun `commands updates convert in both directions`() {
+        val v2 = SessionUpdate.AvailableCommandsUpdate(
+            AvailableCommandsUpdate(
+                availableCommands = listOf(
+                    AvailableCommand(name = "c", description = "d", input = AvailableCommandInput.Text(hint = "h")),
+                ),
+            ),
+        )
+
+        val v1 = assertIs<V1SessionUpdate.AvailableCommandsUpdate>(v2.toV1().single())
+        assertEquals("c", v1.availableCommands.single().name)
+        assertEquals(v2, v1.toV2().let(SessionUpdate::AvailableCommandsUpdate))
+    }
+
+    @Test
+    fun `a commands update with meta cannot be represented in v1`() {
+        val v2 = SessionUpdate.AvailableCommandsUpdate(
+            AvailableCommandsUpdate(
+                availableCommands = emptyList(),
+                _meta = buildJsonObject { put("x", JsonPrimitive(1)) },
+            ),
+        )
+
+        assertFailsWith<ProtocolConversionException> { v2.toV1() }
+    }
+
+    @Test
+    fun `commands whose input cannot cross are skipped`() {
+        val v2 = SessionUpdate.AvailableCommandsUpdate(
+            AvailableCommandsUpdate(
+                availableCommands = listOf(
+                    AvailableCommand(name = "keep", description = "d"),
+                    AvailableCommand(
+                        name = "drop",
+                        description = "d",
+                        input = AvailableCommandInput.Unknown("_vendor", buildJsonObject { }),
+                    ),
+                ),
+            ),
+        )
+
+        val v1 = assertIs<V1SessionUpdate.AvailableCommandsUpdate>(v2.toV1().single())
+        assertEquals(listOf("keep"), v1.availableCommands.map { it.name })
+    }
+
+    @Test
+    fun `session info updates collapse patch states going down and stay unset going up`() {
+        val v2 = SessionUpdate.SessionInfoUpdate(
+            SessionInfoUpdate(title = MaybeUndefined.Value("T"), updatedAt = MaybeUndefined.Null),
+        )
+
+        val v1 = assertIs<V1SessionUpdate.SessionInfoUpdate>(v2.toV1().single())
+        assertEquals("T", v1.title)
+        assertNull(v1.updatedAt)
+
+        val backToV2 = assertIs<SessionUpdate.SessionInfoUpdate>((v1 as V1SessionUpdate).toV2()).update
+        assertEquals(MaybeUndefined.Value("T"), backToV2.title)
+        // An absent v1 field is "no update", never an explicit clear.
+        assertEquals(MaybeUndefined.Undefined, backToV2.updatedAt)
+    }
+
+    @Test
+    fun `a cleared session info meta cannot be represented in v1`() {
+        val v2 = SessionUpdate.SessionInfoUpdate(SessionInfoUpdate(_meta = MaybeUndefined.Null))
+
+        assertFailsWith<ProtocolConversionException> { v2.toV1() }
+    }
+
+    @Test
+    fun `usage updates round-trip`() {
+        val v2 = SessionUpdate.UsageUpdate(UsageUpdate(used = 10, size = 100))
+
+        assertEquals(V1SessionUpdate.UsageUpdate(used = 10, size = 100), v2.toV1().single())
+        assertEquals(v2, V1SessionUpdate.UsageUpdate(used = 10, size = 100).toV2().let(SessionUpdate::UsageUpdate))
+    }
+
+    @Test
+    fun `config option updates round-trip`() {
+        val v1 = V1SessionUpdate.ConfigOptionUpdate(configOptions = emptyList())
+
+        assertEquals(
+            SessionUpdate.ConfigOptionUpdate(ConfigOptionUpdate(configOptions = emptyList())),
+            (v1 as V1SessionUpdate).toV2(),
+        )
+    }
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/SessionUpdateTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/SessionUpdateTest.kt
@@ -1,0 +1,211 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.MessageId
+import com.agentclientprotocol.model.ToolCallId
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+class SessionUpdateTest {
+
+    // Every known variant flattens its payload next to the discriminator
+
+    @Test
+    fun `round-trips the three content chunk variants`() {
+        val payload = """"messageId":"msg_1","content":{"type":"text","text":"hi"}"""
+        val chunk = ContentChunk(messageId = MessageId("msg_1"), content = ContentBlock.Text(text = "hi"))
+
+        val cases = listOf(
+            "user_message_chunk" to SessionUpdate.UserMessageChunk(chunk),
+            "agent_message_chunk" to SessionUpdate.AgentMessageChunk(chunk),
+            "agent_thought_chunk" to SessionUpdate.AgentThoughtChunk(chunk),
+        )
+
+        cases.forEach { (discriminator, update) ->
+            val json = """{"sessionUpdate":"$discriminator",$payload}"""
+            assertEquals(update, decode(json), "decoding $discriminator")
+            assertEquals(json, encode(update), "encoding $discriminator")
+        }
+    }
+
+    @Test
+    fun `round-trips the three message upsert variants`() {
+        val content = MaybeUndefined.Value(listOf<ContentBlock>(ContentBlock.Text(text = "hi")))
+        val payload = """"messageId":"msg_1","content":[{"type":"text","text":"hi"}]"""
+
+        val cases = listOf(
+            "user_message" to SessionUpdate.UserMessage(
+                UserMessage(messageId = MessageId("msg_1"), content = content),
+            ),
+            "agent_message" to SessionUpdate.AgentMessage(
+                AgentMessage(messageId = MessageId("msg_1"), content = content),
+            ),
+            "agent_thought" to SessionUpdate.AgentThought(
+                AgentThought(messageId = MessageId("msg_1"), content = content),
+            ),
+        )
+
+        cases.forEach { (discriminator, update) ->
+            val json = """{"sessionUpdate":"$discriminator",$payload}"""
+            assertEquals(update, decode(json), "decoding $discriminator")
+            assertEquals(json, encode(update), "encoding $discriminator")
+        }
+    }
+
+    @Test
+    fun `round-trips a state update with its own nested discriminator`() {
+        val json = """{"sessionUpdate":"state_update","state":"idle","stopReason":"end_turn"}"""
+        val update = SessionUpdate.StateUpdate(StateUpdate.Idle(stopReason = StopReason.EndTurn))
+
+        assertEquals(update, decode(json))
+        assertEquals(json, encode(update))
+    }
+
+    @Test
+    fun `round-trips a tool call upsert`() {
+        val json = """{"sessionUpdate":"tool_call_update","toolCallId":"tc_1","status":"completed"}"""
+        val update = SessionUpdate.ToolCallUpdate(
+            ToolCallUpdate(
+                toolCallId = ToolCallId("tc_1"),
+                status = MaybeUndefined.Value(ToolCallStatus.Completed),
+            ),
+        )
+
+        assertEquals(update, decode(json))
+        assertEquals(json, encode(update))
+    }
+
+    @Test
+    fun `round-trips a tool call content chunk`() {
+        val json =
+            """{"sessionUpdate":"tool_call_content_chunk","toolCallId":"tc_1",""" +
+                """"content":{"type":"content","content":{"type":"text","text":"out"}}}"""
+        val update = SessionUpdate.ToolCallContentChunk(
+            ToolCallContentChunk(
+                toolCallId = ToolCallId("tc_1"),
+                content = ToolCallContent.Content(content = ContentBlock.Text(text = "out")),
+            ),
+        )
+
+        assertEquals(update, decode(json))
+        assertEquals(json, encode(update))
+    }
+
+    @Test
+    fun `round-trips plan update and plan removal`() {
+        val planUpdate = """{"sessionUpdate":"plan_update","plan":{"type":"items","planId":"main","entries":[]}}"""
+        val planRemoved = """{"sessionUpdate":"plan_removed","planId":"main"}"""
+
+        assertEquals(
+            SessionUpdate.PlanUpdate(
+                PlanUpdate(plan = PlanUpdateContent.Items(planId = PlanId("main"), entries = emptyList())),
+            ),
+            decode(planUpdate),
+        )
+        assertEquals(planUpdate, encode(decode(planUpdate)))
+        assertEquals(SessionUpdate.PlanRemoved(PlanRemoved(planId = PlanId("main"))), decode(planRemoved))
+        assertEquals(planRemoved, encode(decode(planRemoved)))
+    }
+
+    @Test
+    fun `round-trips available commands config options and usage`() {
+        val commands = """{"sessionUpdate":"available_commands_update","availableCommands":[]}"""
+        val configOptions = """{"sessionUpdate":"config_option_update","configOptions":[]}"""
+        val usage = """{"sessionUpdate":"usage_update","used":10,"size":100}"""
+
+        assertEquals(
+            SessionUpdate.AvailableCommandsUpdate(AvailableCommandsUpdate(availableCommands = emptyList())),
+            decode(commands),
+        )
+        assertEquals(commands, encode(decode(commands)))
+        assertEquals(
+            SessionUpdate.ConfigOptionUpdate(ConfigOptionUpdate(configOptions = emptyList())),
+            decode(configOptions),
+        )
+        assertEquals(configOptions, encode(decode(configOptions)))
+        assertEquals(SessionUpdate.UsageUpdate(UsageUpdate(used = 10, size = 100)), decode(usage))
+        assertEquals(usage, encode(decode(usage)))
+    }
+
+    @Test
+    fun `round-trips a session info update with patch semantics`() {
+        val json = """{"sessionUpdate":"session_info_update","title":null}"""
+        val update = SessionUpdate.SessionInfoUpdate(SessionInfoUpdate(title = MaybeUndefined.Null))
+
+        assertEquals(update, decode(json))
+        assertEquals(json, encode(update))
+    }
+
+    @Test
+    fun `an empty session info update encodes as the discriminator alone`() {
+        assertEquals(
+            """{"sessionUpdate":"session_info_update"}""",
+            encode(SessionUpdate.SessionInfoUpdate(SessionInfoUpdate())),
+        )
+    }
+
+    // Open union behaviour
+
+    @Test
+    fun `preserves an unknown session update byte-identically`() {
+        val json = """{"sessionUpdate":"_vendor_telemetry","spans":[{"id":1}]}"""
+
+        val decoded = decode(json)
+        assertIs<SessionUpdate.Unknown>(decoded)
+        assertEquals("_vendor_telemetry", decoded.sessionUpdate)
+        assertEquals(json, encode(decoded))
+    }
+
+    @Test
+    fun `preserves a future ACP session update byte-identically`() {
+        val json = """{"sessionUpdate":"checkpoint_created","checkpointId":"c1"}"""
+
+        val decoded = decode(json)
+        assertIs<SessionUpdate.Unknown>(decoded)
+        assertEquals("checkpoint_created", decoded.sessionUpdate)
+        assertEquals(json, encode(decoded))
+    }
+
+    @Test
+    fun `an unknown nested state still re-emits with both discriminators`() {
+        val json = """{"sessionUpdate":"state_update","state":"_vendor_paused","until":"soon"}"""
+
+        val decoded = decode(json)
+        val stateUpdate = assertIs<SessionUpdate.StateUpdate>(decoded).state
+        assertIs<StateUpdate.Unknown>(stateUpdate)
+        assertEquals("_vendor_paused", stateUpdate.state)
+        assertEquals(json, encode(decoded))
+    }
+
+    @Test
+    fun `missing sessionUpdate discriminator fails`() {
+        assertFailsWith<SerializationException> { decode("""{"toolCallId":"tc_1"}""") }
+    }
+
+    @Test
+    fun `non-string sessionUpdate discriminator fails`() {
+        assertFailsWith<SerializationException> { decode("""{"sessionUpdate":42}""") }
+    }
+
+    @Test
+    fun `known discriminator with a malformed payload fails instead of falling back`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"sessionUpdate":"tool_call_update","status":"completed"}""")
+        }
+        assertFailsWith<SerializationException> {
+            decode("""{"sessionUpdate":"usage_update","used":10}""")
+        }
+    }
+
+    private fun decode(json: String): SessionUpdate =
+        ACPJson.decodeFromString(SessionUpdate.serializer(), json)
+
+    private fun encode(update: SessionUpdate): String =
+        ACPJson.encodeToString(SessionUpdate.serializer(), update)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/StateUpdateTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/StateUpdateTest.kt
@@ -1,0 +1,105 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.Usage
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+class StateUpdateTest {
+
+    // Known states
+
+    @Test
+    fun `decodes the three known states`() {
+        assertEquals(StateUpdate.Running(), decode("""{"state":"running"}"""))
+        assertEquals(StateUpdate.Idle(), decode("""{"state":"idle"}"""))
+        assertEquals(StateUpdate.RequiresAction(), decode("""{"state":"requires_action"}"""))
+    }
+
+    @Test
+    fun `encodes states with a leading state discriminator`() {
+        assertEquals("""{"state":"running"}""", encode(StateUpdate.Running()))
+        assertEquals("""{"state":"requires_action"}""", encode(StateUpdate.RequiresAction()))
+    }
+
+    @Test
+    fun `idle carries an optional stop reason`() {
+        val json = """{"state":"idle","stopReason":"end_turn"}"""
+
+        assertEquals(StateUpdate.Idle(stopReason = StopReason.EndTurn), decode(json))
+        assertEquals(json, encode(StateUpdate.Idle(stopReason = StopReason.EndTurn)))
+    }
+
+    @Test
+    fun `idle carries optional token usage`() {
+        val idle = StateUpdate.Idle(
+            stopReason = StopReason.EndTurn,
+            usage = Usage(inputTokens = 100, outputTokens = 20, totalTokens = 120),
+        )
+        val json =
+            """{"state":"idle","stopReason":"end_turn",""" +
+                """"usage":{"inputTokens":100,"outputTokens":20,"totalTokens":120}}"""
+
+        assertEquals(idle, decode(json))
+        assertEquals(json, encode(idle))
+    }
+
+    @Test
+    fun `idle preserves an unknown stop reason`() {
+        val decoded = decode("""{"state":"idle","stopReason":"_vendor_stop"}""")
+
+        assertIs<StateUpdate.Idle>(decoded)
+        assertEquals(StopReason.Unknown("_vendor_stop"), decoded.stopReason)
+    }
+
+    // Open union behaviour
+
+    @Test
+    fun `preserves an unknown state byte-identically`() {
+        val json = """{"state":"_vendor_paused","until":"2026-01-01T00:00:00Z"}"""
+
+        val decoded = decode(json)
+        assertIs<StateUpdate.Unknown>(decoded)
+        assertEquals("_vendor_paused", decoded.state)
+        assertEquals(json, encode(decoded))
+    }
+
+    @Test
+    fun `preserves a future ACP state byte-identically`() {
+        val json = """{"state":"suspended","reason":"quota"}"""
+
+        val decoded = decode(json)
+        assertIs<StateUpdate.Unknown>(decoded)
+        assertEquals("suspended", decoded.state)
+        assertEquals(json, encode(decoded))
+    }
+
+    @Test
+    fun `missing state discriminator fails`() {
+        assertFailsWith<SerializationException> { decode("""{"stopReason":"end_turn"}""") }
+    }
+
+    @Test
+    fun `non-string state discriminator fails`() {
+        assertFailsWith<SerializationException> { decode("""{"state":42}""") }
+    }
+
+    @Test
+    fun `known state with a malformed payload fails instead of falling back`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"state":"idle","usage":{"inputTokens":"not a number"}}""")
+        }
+    }
+
+    private fun decode(json: String): StateUpdate =
+        ACPJson.decodeFromString(StateUpdate.serializer(), json)
+
+    private fun encode(update: StateUpdate): String =
+        ACPJson.encodeToString(StateUpdate.serializer(), update)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/StopReasonTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/StopReasonTest.kt
@@ -1,0 +1,97 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.StopReason as V1StopReason
+
+class StopReasonTest {
+
+    // Known values
+
+    @Test
+    fun `decodes all known values`() {
+        assertEquals(StopReason.EndTurn, decode("\"end_turn\""))
+        assertEquals(StopReason.MaxTokens, decode("\"max_tokens\""))
+        assertEquals(StopReason.MaxTurnRequests, decode("\"max_turn_requests\""))
+        assertEquals(StopReason.Refusal, decode("\"refusal\""))
+        assertEquals(StopReason.Cancelled, decode("\"cancelled\""))
+    }
+
+    @Test
+    fun `encodes all known values`() {
+        assertEquals("\"end_turn\"", encode(StopReason.EndTurn))
+        assertEquals("\"max_tokens\"", encode(StopReason.MaxTokens))
+        assertEquals("\"max_turn_requests\"", encode(StopReason.MaxTurnRequests))
+        assertEquals("\"refusal\"", encode(StopReason.Refusal))
+        assertEquals("\"cancelled\"", encode(StopReason.Cancelled))
+    }
+
+    // Unknown values (forward compatibility)
+
+    @Test
+    fun `decodes unknown value as Unknown and round-trips byte-identically`() {
+        val reason = decode("\"max_cost\"")
+
+        assertIs<StopReason.Unknown>(reason)
+        assertEquals("max_cost", reason.value)
+        assertEquals("\"_vendor_reason\"", encode(decode("\"_vendor_reason\"")))
+    }
+
+    // Extension factory
+
+    @Test
+    fun `extension creates Unknown for underscore-prefixed values`() {
+        assertEquals(StopReason.extension("_vendor_reason"), StopReason.Unknown("_vendor_reason"))
+    }
+
+    @Test
+    fun `extension rejects values without underscore prefix`() {
+        assertFailsWith<IllegalArgumentException> {
+            StopReason.extension("vendor_reason")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts all known values to v1`() {
+        assertEquals(V1StopReason.END_TURN, StopReason.EndTurn.toV1())
+        assertEquals(V1StopReason.MAX_TOKENS, StopReason.MaxTokens.toV1())
+        assertEquals(V1StopReason.MAX_TURN_REQUESTS, StopReason.MaxTurnRequests.toV1())
+        assertEquals(V1StopReason.REFUSAL, StopReason.Refusal.toV1())
+        assertEquals(V1StopReason.CANCELLED, StopReason.Cancelled.toV1())
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            StopReason.Unknown("max_cost").toV1()
+        }
+
+        assertEquals("v2 StopReason variant `max_cost` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converts all v1 values to v2`() {
+        assertEquals(StopReason.EndTurn, V1StopReason.END_TURN.toV2())
+        assertEquals(StopReason.MaxTokens, V1StopReason.MAX_TOKENS.toV2())
+        assertEquals(StopReason.MaxTurnRequests, V1StopReason.MAX_TURN_REQUESTS.toV2())
+        assertEquals(StopReason.Refusal, V1StopReason.REFUSAL.toV2())
+        assertEquals(StopReason.Cancelled, V1StopReason.CANCELLED.toV2())
+    }
+
+    private fun decode(json: String): StopReason =
+        ACPJson.decodeFromString(StopReason.serializer(), json)
+
+    private fun encode(reason: StopReason): String =
+        ACPJson.encodeToString(StopReason.serializer(), reason)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/StringFormatTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/StringFormatTest.kt
@@ -1,0 +1,93 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.StringFormat as V1StringFormat
+
+class StringFormatTest {
+
+    // Known values
+
+    @Test
+    fun `decodes all known values`() {
+        assertEquals(StringFormat.Email, decode("\"email\""))
+        assertEquals(StringFormat.Uri, decode("\"uri\""))
+        assertEquals(StringFormat.Date, decode("\"date\""))
+        assertEquals(StringFormat.DateTime, decode("\"date-time\""))
+    }
+
+    @Test
+    fun `encodes all known values`() {
+        assertEquals("\"email\"", encode(StringFormat.Email))
+        assertEquals("\"uri\"", encode(StringFormat.Uri))
+        assertEquals("\"date\"", encode(StringFormat.Date))
+        assertEquals("\"date-time\"", encode(StringFormat.DateTime))
+    }
+
+    // Unknown values (forward compatibility)
+
+    @Test
+    fun `decodes unknown value as Unknown and round-trips byte-identically`() {
+        val format = decode("\"hostname\"")
+
+        assertIs<StringFormat.Unknown>(format)
+        assertEquals("hostname", format.value)
+        assertEquals("\"_vendor_format\"", encode(decode("\"_vendor_format\"")))
+    }
+
+    // Extension factory
+
+    @Test
+    fun `extension creates Unknown for underscore-prefixed values`() {
+        assertEquals(StringFormat.extension("_vendor_format"), StringFormat.Unknown("_vendor_format"))
+    }
+
+    @Test
+    fun `extension rejects values without underscore prefix`() {
+        assertFailsWith<IllegalArgumentException> {
+            StringFormat.extension("vendor_format")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts all known values to v1`() {
+        assertEquals(V1StringFormat.EMAIL, StringFormat.Email.toV1())
+        assertEquals(V1StringFormat.URI, StringFormat.Uri.toV1())
+        assertEquals(V1StringFormat.DATE, StringFormat.Date.toV1())
+        assertEquals(V1StringFormat.DATE_TIME, StringFormat.DateTime.toV1())
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            StringFormat.Unknown("hostname").toV1()
+        }
+
+        assertEquals("v2 StringFormat variant `hostname` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converts all v1 values to v2`() {
+        assertEquals(StringFormat.Email, V1StringFormat.EMAIL.toV2())
+        assertEquals(StringFormat.Uri, V1StringFormat.URI.toV2())
+        assertEquals(StringFormat.Date, V1StringFormat.DATE.toV2())
+        assertEquals(StringFormat.DateTime, V1StringFormat.DATE_TIME.toV2())
+    }
+
+    private fun decode(json: String): StringFormat =
+        ACPJson.decodeFromString(StringFormat.serializer(), json)
+
+    private fun encode(format: StringFormat): String =
+        ACPJson.encodeToString(StringFormat.serializer(), format)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ToolCallContentChunkTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ToolCallContentChunkTest.kt
@@ -1,0 +1,61 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.ToolCallId
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+class ToolCallContentChunkTest {
+
+    private val chunk = ToolCallContentChunk(
+        toolCallId = ToolCallId("tc_1"),
+        content = ToolCallContent.Content(content = ContentBlock.Text(text = "line 1")),
+    )
+
+    private val chunkJson =
+        """{"toolCallId":"tc_1","content":{"type":"content","content":{"type":"text","text":"line 1"}}}"""
+
+    @Test
+    fun `decodes a chunk with a single content item`() {
+        assertEquals(chunk, decode(chunkJson))
+    }
+
+    @Test
+    fun `encodes a chunk without optional meta`() {
+        assertEquals(chunkJson, encode(chunk))
+    }
+
+    @Test
+    fun `preserves unknown content types as raw json`() {
+        val json = """{"toolCallId":"tc_1","content":{"type":"_vendor_chart","points":[1,2]}}"""
+
+        val decoded = decode(json)
+        assertIs<ToolCallContent.Unknown>(decoded.content)
+        assertEquals("_vendor_chart", decoded.content.type)
+        assertEquals(json, encode(decoded))
+    }
+
+    @Test
+    fun `requires a tool call id`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"content":{"type":"content","content":{"type":"text","text":"line 1"}}}""")
+        }
+    }
+
+    @Test
+    fun `requires content`() {
+        assertFailsWith<SerializationException> { decode("""{"toolCallId":"tc_1"}""") }
+    }
+
+    private fun decode(json: String): ToolCallContentChunk =
+        ACPJson.decodeFromString(ToolCallContentChunk.serializer(), json)
+
+    private fun encode(chunk: ToolCallContentChunk): String =
+        ACPJson.encodeToString(ToolCallContentChunk.serializer(), chunk)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ToolCallContentTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ToolCallContentTest.kt
@@ -1,0 +1,159 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+class ToolCallContentTest {
+
+    // Known variants
+
+    @Test
+    fun `decodes the content variant with a nested content block`() {
+        assertEquals(
+            ToolCallContent.Content(content = ContentBlock.Text(text = "hello")),
+            decode("""{"type":"content","content":{"type":"text","text":"hello"}}"""),
+        )
+    }
+
+    @Test
+    fun `encodes the content variant with leading discriminator`() {
+        assertEquals(
+            """{"type":"content","content":{"type":"text","text":"hello"}}""",
+            encode(ToolCallContent.Content(content = ContentBlock.Text(text = "hello"))),
+        )
+    }
+
+    @Test
+    fun `decodes the diff variant with structured changes and patch`() {
+        val json = """
+            {"type":"diff","changes":[
+                {"operation":"modify","path":"/src/main.rs","fileType":"text"},
+                {"operation":"move","oldPath":"/old.rs","path":"/new.rs"}
+            ],"patch":{"format":"git_patch","diff":"--- a/src/main.rs"}}
+        """.trimIndent().replace(Regex("\\n\\s*"), "")
+
+        assertEquals(
+            ToolCallContent.Diff(
+                changes = listOf(
+                    DiffChange(
+                        operation = DiffChangeOperation.Modify(path = "/src/main.rs"),
+                        fileType = DiffFileType.Text,
+                    ),
+                    DiffChange(operation = DiffChangeOperation.Move(oldPath = "/old.rs", path = "/new.rs")),
+                ),
+                patch = DiffPatch(diff = "--- a/src/main.rs"),
+            ),
+            decode(json),
+        )
+    }
+
+    @Test
+    fun `diff variant round-trips`() {
+        val diff = ToolCallContent.Diff(
+            changes = listOf(
+                DiffChange(
+                    operation = DiffChangeOperation.Add(path = "/a.txt"),
+                    fileType = DiffFileType.Text,
+                    mimeType = "text/plain",
+                ),
+                DiffChange(operation = DiffChangeOperation.Copy(oldPath = "/a.txt", path = "/b.txt")),
+                DiffChange(operation = DiffChangeOperation.Delete(path = "/c.bin"), fileType = DiffFileType.Binary),
+            ),
+            patch = DiffPatch(diff = "diff --git a/a.txt b/a.txt"),
+        )
+
+        assertEquals(diff, decode(encode(diff)))
+    }
+
+    // Open leaves of the diff graph
+
+    @Test
+    fun `unknown diff change operation is preserved with its fields`() {
+        val json = """{"type":"diff","changes":[{"operation":"archive","target":"/backup.tar","fileType":"text"}]}"""
+
+        val diff = decode(json)
+
+        assertIs<ToolCallContent.Diff>(diff)
+        val change = diff.changes.single()
+        val operation = change.operation
+        assertIs<DiffChangeOperation.Unknown>(operation)
+        assertEquals("archive", operation.operation)
+        assertEquals(DiffFileType.Text, change.fileType)
+        assertEquals(json, encode(diff))
+    }
+
+    @Test
+    fun `unknown file type and patch format deserialize to Unknown`() {
+        val diff = decode(
+            """{"type":"diff","changes":[{"operation":"add","path":"/a","fileType":"socket"}],""" +
+                """"patch":{"format":"_vendor_patch","diff":"x"}}""",
+        )
+
+        assertIs<ToolCallContent.Diff>(diff)
+        assertEquals(DiffFileType.Unknown("socket"), diff.changes.single().fileType)
+        assertEquals(DiffPatchFormat.Unknown("_vendor_patch"), diff.patch?.format)
+    }
+
+    @Test
+    fun `diff change without operation fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"type":"diff","changes":[{"path":"/a.txt"}]}""")
+        }
+    }
+
+    @Test
+    fun `known operation with missing path fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"type":"diff","changes":[{"operation":"add"}]}""")
+        }
+    }
+
+    // Unknown discriminators (forward compatibility)
+
+    @Test
+    fun `decodes unknown content type as Unknown preserving the full payload`() {
+        val json = """{"type":"terminal","terminalId":"term-1"}"""
+
+        val content = decode(json)
+
+        assertIs<ToolCallContent.Unknown>(content)
+        assertEquals("terminal", content.type)
+        assertEquals(json, encode(content))
+    }
+
+    @Test
+    fun `underscore-prefixed extension content round-trips byte-identically`() {
+        val json = """{"type":"_vendor_preview","frames":[1,2]}"""
+
+        assertEquals(json, encode(decode(json)))
+    }
+
+    // Strictness
+
+    @Test
+    fun `missing discriminator fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"content":{"type":"text","text":"hello"}}""")
+        }
+    }
+
+    @Test
+    fun `known discriminator with malformed payload fails instead of falling back`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"type":"content"}""")
+        }
+    }
+
+    private fun decode(json: String): ToolCallContent =
+        ACPJson.decodeFromString(ToolCallContent.serializer(), json)
+
+    private fun encode(content: ToolCallContent): String =
+        ACPJson.encodeToString(ToolCallContent.serializer(), content)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ToolCallStatusTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ToolCallStatusTest.kt
@@ -1,0 +1,127 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.ToolCallStatus as V1ToolCallStatus
+
+class ToolCallStatusTest {
+
+    // Known values
+
+    @Test
+    fun `decodes all known values`() {
+        assertEquals(ToolCallStatus.Pending, decode("\"pending\""))
+        assertEquals(ToolCallStatus.InProgress, decode("\"in_progress\""))
+        assertEquals(ToolCallStatus.Completed, decode("\"completed\""))
+        assertEquals(ToolCallStatus.Failed, decode("\"failed\""))
+    }
+
+    @Test
+    fun `encodes all known values`() {
+        assertEquals("\"pending\"", encode(ToolCallStatus.Pending))
+        assertEquals("\"in_progress\"", encode(ToolCallStatus.InProgress))
+        assertEquals("\"completed\"", encode(ToolCallStatus.Completed))
+        assertEquals("\"failed\"", encode(ToolCallStatus.Failed))
+    }
+
+    // Unknown values (forward compatibility)
+
+    @Test
+    fun `decodes unknown ACP-reserved value as Unknown and preserves it`() {
+        val status = decode("\"deferred\"")
+
+        assertIs<ToolCallStatus.Unknown>(status)
+        assertEquals("deferred", status.value)
+    }
+
+    @Test
+    fun `decodes underscore-prefixed extension value as Unknown`() {
+        val status = decode("\"_vendor_paused\"")
+
+        assertIs<ToolCallStatus.Unknown>(status)
+        assertEquals("_vendor_paused", status.value)
+    }
+
+    @Test
+    fun `unknown value round-trips byte-identically`() {
+        val json = "\"_vendor_paused\""
+
+        assertEquals(json, encode(decode(json)))
+    }
+
+    @Test
+    fun `Unknown carrying a known wire value normalizes to the known variant on round-trip`() {
+        // Same semantics as Rust's #[serde(untagged)] fallback: the wire format has no
+        // marker distinguishing Unknown("pending") from Pending, so decode prefers known.
+        val decoded = decode(encode(ToolCallStatus.Unknown("pending")))
+
+        assertEquals(ToolCallStatus.Pending, decoded)
+    }
+
+    @Test
+    fun `decodes unknown value inside an enclosing object`() {
+        @Serializable
+        data class Wrapper(val status: ToolCallStatus)
+
+        val wrapper = ACPJson.decodeFromString(Wrapper.serializer(), """{"status":"deferred"}""")
+
+        assertEquals(ToolCallStatus.Unknown("deferred"), wrapper.status)
+    }
+
+    // Extension factory
+
+    @Test
+    fun `extension creates Unknown for underscore-prefixed values`() {
+        assertEquals(ToolCallStatus.extension("_vendor_paused"), ToolCallStatus.Unknown("_vendor_paused"))
+    }
+
+    @Test
+    fun `extension rejects values without underscore prefix`() {
+        assertFailsWith<IllegalArgumentException> {
+            ToolCallStatus.extension("vendor_paused")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts all known values to v1`() {
+        assertEquals(V1ToolCallStatus.PENDING, ToolCallStatus.Pending.toV1())
+        assertEquals(V1ToolCallStatus.IN_PROGRESS, ToolCallStatus.InProgress.toV1())
+        assertEquals(V1ToolCallStatus.COMPLETED, ToolCallStatus.Completed.toV1())
+        assertEquals(V1ToolCallStatus.FAILED, ToolCallStatus.Failed.toV1())
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            ToolCallStatus.Unknown("deferred").toV1()
+        }
+
+        assertEquals("v2 ToolCallStatus variant `deferred` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converts all v1 values to v2`() {
+        assertEquals(ToolCallStatus.Pending, V1ToolCallStatus.PENDING.toV2())
+        assertEquals(ToolCallStatus.InProgress, V1ToolCallStatus.IN_PROGRESS.toV2())
+        assertEquals(ToolCallStatus.Completed, V1ToolCallStatus.COMPLETED.toV2())
+        assertEquals(ToolCallStatus.Failed, V1ToolCallStatus.FAILED.toV2())
+    }
+
+    private fun decode(json: String): ToolCallStatus =
+        ACPJson.decodeFromString(ToolCallStatus.serializer(), json)
+
+    private fun encode(status: ToolCallStatus): String =
+        ACPJson.encodeToString(ToolCallStatus.serializer(), status)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ToolCallUpdateTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ToolCallUpdateTest.kt
@@ -1,0 +1,196 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.ToolCallId
+import com.agentclientprotocol.model.ToolCallLocation
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+class ToolCallUpdateTest {
+
+    // Encoding: Undefined is omitted, Null is an explicit null, Value is encoded
+
+    @Test
+    fun `encodes only set fields as an upsert`() {
+        val update = ToolCallUpdate(
+            toolCallId = ToolCallId("tc_1"),
+            title = MaybeUndefined.Value("Reading configuration"),
+            status = MaybeUndefined.Value(ToolCallStatus.InProgress),
+            rawInput = MaybeUndefined.Value(buildJsonObject { put("path", "settings.json") }),
+        )
+
+        assertEquals(
+            """{"toolCallId":"tc_1","title":"Reading configuration","status":"in_progress","rawInput":{"path":"settings.json"}}""",
+            encode(update),
+        )
+    }
+
+    @Test
+    fun `encodes an explicit null for cleared fields`() {
+        val update = ToolCallUpdate(
+            toolCallId = ToolCallId("tc_1"),
+            status = MaybeUndefined.Value(ToolCallStatus.Completed),
+            content = MaybeUndefined.Null,
+        )
+
+        assertEquals(
+            """{"toolCallId":"tc_1","status":"completed","content":null}""",
+            encode(update),
+        )
+    }
+
+    @Test
+    fun `encodes an explicit null for cleared meta`() {
+        assertEquals(
+            """{"toolCallId":"tc_1","_meta":null}""",
+            encode(ToolCallUpdate(toolCallId = ToolCallId("tc_1"), _meta = MaybeUndefined.Null)),
+        )
+    }
+
+    // Decoding: absent, null, and value are three distinct states
+
+    @Test
+    fun `decodes omitted null and value states distinctly`() {
+        val update = decode("""{"toolCallId":"tc_1","status":null,"locations":[]}""")
+
+        assertEquals(MaybeUndefined.Undefined, update.title)
+        assertEquals(MaybeUndefined.Null, update.status)
+        assertEquals(MaybeUndefined.Value(emptyList()), update.locations)
+    }
+
+    @Test
+    fun `decodes meta omitted vs null vs value`() {
+        assertEquals(
+            MaybeUndefined.Undefined,
+            decode("""{"toolCallId":"tc_1"}""")._meta,
+        )
+        assertEquals(
+            MaybeUndefined.Null,
+            decode("""{"toolCallId":"tc_1","_meta":null}""")._meta,
+        )
+        assertEquals(
+            MaybeUndefined.Value(buildJsonObject { put("source", "tool-call") }),
+            decode("""{"toolCallId":"tc_1","_meta":{"source":"tool-call"}}""")._meta,
+        )
+    }
+
+    @Test
+    fun `round-trips a fully populated update byte-identically`() {
+        val json = """{"toolCallId":"tc_1","title":"Edit","kind":"edit","status":"in_progress",""" +
+            """"content":[{"type":"content","content":{"type":"text","text":"ok"}}],""" +
+            """"locations":[{"path":"/f.txt","line":3}],"rawInput":{"a":1},"rawOutput":null,"_meta":{"k":"v"}}"""
+
+        assertEquals(json, encode(decode(json)))
+    }
+
+    // Open enum leaves stay open
+
+    @Test
+    fun `unknown kind string is preserved as an open enum value`() {
+        assertEquals(
+            MaybeUndefined.Value(ToolKind.Unknown("quantum")),
+            decode("""{"toolCallId":"tc_1","kind":"quantum"}""").kind,
+        )
+    }
+
+    // Graceful degradation (Rust DefaultOnError / VecSkipError)
+
+    @Test
+    fun `malformed optional fields degrade to undefined instead of failing`() {
+        val update = decode("""{"toolCallId":"tc_1","title":{"a":1},"kind":[],"content":"nope"}""")
+
+        assertEquals(MaybeUndefined.Undefined, update.title)
+        assertEquals(MaybeUndefined.Undefined, update.kind)
+        assertEquals(MaybeUndefined.Undefined, update.content)
+    }
+
+    @Test
+    fun `skips malformed list items but keeps valid ones`() {
+        val update = decode(
+            """{"toolCallId":"tc_1","content":[""" +
+                """{"type":"content","content":{"type":"text","text":"ok"}},""" +
+                """{"type":"diff","path":"/bad"}],""" +
+                """"locations":[{"path":"/ok","line":3},{"line":4}]}"""
+        )
+
+        val content = assertIs<MaybeUndefined.Value<List<ToolCallContent>>>(update.content)
+        assertEquals(listOf<ToolCallContent>(ToolCallContent.Content(ContentBlock.Text(text = "ok"))), content.value)
+
+        val locations = assertIs<MaybeUndefined.Value<List<ToolCallLocation>>>(update.locations)
+        assertEquals(listOf(ToolCallLocation(path = "/ok", line = 3u)), locations.value)
+    }
+
+    @Test
+    fun `unknown content item types are preserved not skipped`() {
+        val update = decode(
+            """{"toolCallId":"tc_1","content":[{"type":"terminal","terminalId":"term-1"}]}"""
+        )
+
+        val content = assertIs<MaybeUndefined.Value<List<ToolCallContent>>>(update.content)
+        val item = assertIs<ToolCallContent.Unknown>(content.value.single())
+        assertEquals("terminal", item.type)
+    }
+
+    // Strictness: the one required field still fails hard
+
+    @Test
+    fun `missing toolCallId fails`() {
+        assertFailsWith<SerializationException> {
+            decode("""{"title":"Reading configuration"}""")
+        }
+    }
+
+    // Upsert application
+
+    @Test
+    fun `applyUpdate patches stored state and preserves explicit nulls`() {
+        val stored = ToolCallUpdate(
+            toolCallId = ToolCallId("tc_1"),
+            title = MaybeUndefined.Value("Reading configuration"),
+            status = MaybeUndefined.Value(ToolCallStatus.InProgress),
+            _meta = MaybeUndefined.Value(JsonPrimitive("keep")),
+        )
+
+        val patched = stored.applyUpdate(
+            ToolCallUpdate(
+                toolCallId = ToolCallId("tc_1"),
+                status = MaybeUndefined.Value(ToolCallStatus.Completed),
+                _meta = MaybeUndefined.Null,
+            )
+        )
+
+        assertEquals(MaybeUndefined.Value("Reading configuration"), patched.title)
+        assertEquals(MaybeUndefined.Value(ToolCallStatus.Completed), patched.status)
+        assertEquals(MaybeUndefined.Null, patched._meta)
+    }
+
+    @Test
+    fun `applyUpdate rejects a different toolCallId`() {
+        assertFailsWith<IllegalArgumentException> {
+            ToolCallUpdate(toolCallId = ToolCallId("tc_1"))
+                .applyUpdate(ToolCallUpdate(toolCallId = ToolCallId("tc_2")))
+        }
+    }
+
+    @Test
+    fun `update resolves patch states against a previous value`() {
+        assertEquals("new", MaybeUndefined.Value("new").update("old"))
+        assertEquals("old", MaybeUndefined.Undefined.update("old"))
+        assertEquals(null, MaybeUndefined.Null.update("old"))
+    }
+
+    private fun decode(json: String): ToolCallUpdate =
+        ACPJson.decodeFromString(ToolCallUpdate.serializer(), json)
+
+    private fun encode(update: ToolCallUpdate): String =
+        ACPJson.encodeToString(ToolCallUpdate.serializer(), update)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ToolKindTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ToolKindTest.kt
@@ -1,0 +1,122 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.v2.conversion.ProtocolConversionException
+import com.agentclientprotocol.model.v2.conversion.toV1
+import com.agentclientprotocol.model.v2.conversion.toV2
+import com.agentclientprotocol.rpc.ACPJson
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import com.agentclientprotocol.model.ToolKind as V1ToolKind
+
+class ToolKindTest {
+
+    // Known values
+
+    @Test
+    fun `decodes all known values`() {
+        assertEquals(ToolKind.Read, decode("\"read\""))
+        assertEquals(ToolKind.Edit, decode("\"edit\""))
+        assertEquals(ToolKind.Delete, decode("\"delete\""))
+        assertEquals(ToolKind.Move, decode("\"move\""))
+        assertEquals(ToolKind.Search, decode("\"search\""))
+        assertEquals(ToolKind.Execute, decode("\"execute\""))
+        assertEquals(ToolKind.Think, decode("\"think\""))
+        assertEquals(ToolKind.Fetch, decode("\"fetch\""))
+        assertEquals(ToolKind.SwitchMode, decode("\"switch_mode\""))
+        assertEquals(ToolKind.Other, decode("\"other\""))
+    }
+
+    @Test
+    fun `encodes all known values`() {
+        assertEquals("\"read\"", encode(ToolKind.Read))
+        assertEquals("\"edit\"", encode(ToolKind.Edit))
+        assertEquals("\"delete\"", encode(ToolKind.Delete))
+        assertEquals("\"move\"", encode(ToolKind.Move))
+        assertEquals("\"search\"", encode(ToolKind.Search))
+        assertEquals("\"execute\"", encode(ToolKind.Execute))
+        assertEquals("\"think\"", encode(ToolKind.Think))
+        assertEquals("\"fetch\"", encode(ToolKind.Fetch))
+        assertEquals("\"switch_mode\"", encode(ToolKind.SwitchMode))
+        assertEquals("\"other\"", encode(ToolKind.Other))
+    }
+
+    // Unknown values (forward compatibility)
+
+    @Test
+    fun `decodes unknown value as Unknown and round-trips byte-identically`() {
+        val kind = decode("\"compress\"")
+
+        assertIs<ToolKind.Unknown>(kind)
+        assertEquals("compress", kind.value)
+        assertEquals("\"_vendor_kind\"", encode(decode("\"_vendor_kind\"")))
+    }
+
+    @Test
+    fun `unknown value 'other' decodes to the known Other variant not Unknown`() {
+        assertEquals(ToolKind.Other, decode("\"other\""))
+    }
+
+    // Extension factory
+
+    @Test
+    fun `extension creates Unknown for underscore-prefixed values`() {
+        assertEquals(ToolKind.extension("_vendor_kind"), ToolKind.Unknown("_vendor_kind"))
+    }
+
+    @Test
+    fun `extension rejects values without underscore prefix`() {
+        assertFailsWith<IllegalArgumentException> {
+            ToolKind.extension("vendor_kind")
+        }
+    }
+
+    // v2 <-> v1 conversion
+
+    @Test
+    fun `converts all known values to v1`() {
+        assertEquals(V1ToolKind.READ, ToolKind.Read.toV1())
+        assertEquals(V1ToolKind.EDIT, ToolKind.Edit.toV1())
+        assertEquals(V1ToolKind.DELETE, ToolKind.Delete.toV1())
+        assertEquals(V1ToolKind.MOVE, ToolKind.Move.toV1())
+        assertEquals(V1ToolKind.SEARCH, ToolKind.Search.toV1())
+        assertEquals(V1ToolKind.EXECUTE, ToolKind.Execute.toV1())
+        assertEquals(V1ToolKind.THINK, ToolKind.Think.toV1())
+        assertEquals(V1ToolKind.FETCH, ToolKind.Fetch.toV1())
+        assertEquals(V1ToolKind.SWITCH_MODE, ToolKind.SwitchMode.toV1())
+        assertEquals(V1ToolKind.OTHER, ToolKind.Other.toV1())
+    }
+
+    @Test
+    fun `converting Unknown to v1 fails instead of losing data`() {
+        val exception = assertFailsWith<ProtocolConversionException> {
+            ToolKind.Unknown("compress").toV1()
+        }
+
+        assertEquals("v2 ToolKind variant `compress` cannot be represented in v1", exception.message)
+    }
+
+    @Test
+    fun `converts all v1 values to v2`() {
+        assertEquals(ToolKind.Read, V1ToolKind.READ.toV2())
+        assertEquals(ToolKind.Edit, V1ToolKind.EDIT.toV2())
+        assertEquals(ToolKind.Delete, V1ToolKind.DELETE.toV2())
+        assertEquals(ToolKind.Move, V1ToolKind.MOVE.toV2())
+        assertEquals(ToolKind.Search, V1ToolKind.SEARCH.toV2())
+        assertEquals(ToolKind.Execute, V1ToolKind.EXECUTE.toV2())
+        assertEquals(ToolKind.Think, V1ToolKind.THINK.toV2())
+        assertEquals(ToolKind.Fetch, V1ToolKind.FETCH.toV2())
+        assertEquals(ToolKind.SwitchMode, V1ToolKind.SWITCH_MODE.toV2())
+        assertEquals(ToolKind.Other, V1ToolKind.OTHER.toV2())
+    }
+
+    private fun decode(json: String): ToolKind =
+        ACPJson.decodeFromString(ToolKind.serializer(), json)
+
+    private fun encode(kind: ToolKind): String =
+        ACPJson.encodeToString(ToolKind.serializer(), kind)
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/UsageUpdateTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/UsageUpdateTest.kt
@@ -1,0 +1,51 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.model.Cost
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class UsageUpdateTest {
+
+    @Test
+    fun `decodes context usage with a cumulative cost`() {
+        assertEquals(
+            UsageUpdate(used = 12_000, size = 200_000, cost = Cost(amount = 0.42, currency = "USD")),
+            decode("""{"used":12000,"size":200000,"cost":{"amount":0.42,"currency":"USD"}}"""),
+        )
+    }
+
+    @Test
+    fun `encodes context usage with a cumulative cost`() {
+        assertEquals(
+            """{"used":12000,"size":200000,"cost":{"amount":0.42,"currency":"USD"}}""",
+            encode(UsageUpdate(used = 12_000, size = 200_000, cost = Cost(amount = 0.42, currency = "USD"))),
+        )
+    }
+
+    @Test
+    fun `omits an absent cost`() {
+        val update = UsageUpdate(used = 1, size = 2)
+
+        assertEquals("""{"used":1,"size":2}""", encode(update))
+        assertNull(decode("""{"used":1,"size":2}""").cost)
+    }
+
+    @Test
+    fun `requires both token counts`() {
+        assertFailsWith<SerializationException> { decode("""{"used":1}""") }
+        assertFailsWith<SerializationException> { decode("""{"size":2}""") }
+    }
+
+    private fun decode(json: String): UsageUpdate =
+        ACPJson.decodeFromString(UsageUpdate.serializer(), json)
+
+    private fun encode(update: UsageUpdate): String =
+        ACPJson.encodeToString(UsageUpdate.serializer(), update)
+}


### PR DESCRIPTION
This is the draft that contains support for following: 
- enums and tagged unions to accept unknown values
- Updates are upserts schema-side support

In order to merge this PR it's better to implement protocol version negotiation first, because for now new schema is just unable to be used.