### PR TITLE
Preserve metadata on elicitation property schemas

### DIFF
--- a/acp-model/api/acp-model.api
+++ b/acp-model/api/acp-model.api
@@ -1935,7 +1935,7 @@ public final class com/agentclientprotocol/model/ElicitationMode$Url$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public abstract class com/agentclientprotocol/model/ElicitationPropertySchema {
+public abstract class com/agentclientprotocol/model/ElicitationPropertySchema : com/agentclientprotocol/model/AcpWithMeta {
 	public static final field Companion Lcom/agentclientprotocol/model/ElicitationPropertySchema$Companion;
 	public synthetic fun <init> (ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
 	public static final synthetic fun write$Self (Lcom/agentclientprotocol/model/ElicitationPropertySchema;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
@@ -1943,16 +1943,17 @@ public abstract class com/agentclientprotocol/model/ElicitationPropertySchema {
 
 public final class com/agentclientprotocol/model/ElicitationPropertySchema$ArrayProperty : com/agentclientprotocol/model/ElicitationPropertySchema {
 	public static final field Companion Lcom/agentclientprotocol/model/ElicitationPropertySchema$ArrayProperty$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lcom/agentclientprotocol/model/MultiSelectItems;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lcom/agentclientprotocol/model/MultiSelectItems;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lcom/agentclientprotocol/model/MultiSelectItems;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lcom/agentclientprotocol/model/MultiSelectItems;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/Long;
 	public final fun component4 ()Ljava/lang/Long;
 	public final fun component5 ()Lcom/agentclientprotocol/model/MultiSelectItems;
 	public final fun component6 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lcom/agentclientprotocol/model/MultiSelectItems;Ljava/util/List;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$ArrayProperty;
-	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/ElicitationPropertySchema$ArrayProperty;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lcom/agentclientprotocol/model/MultiSelectItems;Ljava/util/List;ILjava/lang/Object;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$ArrayProperty;
+	public final fun component7 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lcom/agentclientprotocol/model/MultiSelectItems;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$ArrayProperty;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/ElicitationPropertySchema$ArrayProperty;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Lcom/agentclientprotocol/model/MultiSelectItems;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$ArrayProperty;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDefault ()Ljava/util/List;
 	public final fun getDescription ()Ljava/lang/String;
@@ -1960,6 +1961,7 @@ public final class com/agentclientprotocol/model/ElicitationPropertySchema$Array
 	public final fun getMaxItems ()Ljava/lang/Long;
 	public final fun getMinItems ()Ljava/lang/Long;
 	public final fun getTitle ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1982,17 +1984,19 @@ public final class com/agentclientprotocol/model/ElicitationPropertySchema$Array
 public final class com/agentclientprotocol/model/ElicitationPropertySchema$BooleanProperty : com/agentclientprotocol/model/ElicitationPropertySchema {
 	public static final field Companion Lcom/agentclientprotocol/model/ElicitationPropertySchema$BooleanProperty$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/Boolean;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$BooleanProperty;
-	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/ElicitationPropertySchema$BooleanProperty;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$BooleanProperty;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$BooleanProperty;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/ElicitationPropertySchema$BooleanProperty;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$BooleanProperty;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDefault ()Ljava/lang/Boolean;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getTitle ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -2019,21 +2023,23 @@ public final class com/agentclientprotocol/model/ElicitationPropertySchema$Compa
 public final class com/agentclientprotocol/model/ElicitationPropertySchema$IntegerProperty : com/agentclientprotocol/model/ElicitationPropertySchema {
 	public static final field Companion Lcom/agentclientprotocol/model/ElicitationPropertySchema$IntegerProperty$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/Long;
 	public final fun component4 ()Ljava/lang/Long;
 	public final fun component5 ()Ljava/lang/Long;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$IntegerProperty;
-	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/ElicitationPropertySchema$IntegerProperty;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;ILjava/lang/Object;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$IntegerProperty;
+	public final fun component6 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$IntegerProperty;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/ElicitationPropertySchema$IntegerProperty;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$IntegerProperty;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDefault ()Ljava/lang/Long;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getMaximum ()Ljava/lang/Long;
 	public final fun getMinimum ()Ljava/lang/Long;
 	public final fun getTitle ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -2056,21 +2062,23 @@ public final class com/agentclientprotocol/model/ElicitationPropertySchema$Integ
 public final class com/agentclientprotocol/model/ElicitationPropertySchema$NumberProperty : com/agentclientprotocol/model/ElicitationPropertySchema {
 	public static final field Companion Lcom/agentclientprotocol/model/ElicitationPropertySchema$NumberProperty$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/Double;
 	public final fun component4 ()Ljava/lang/Double;
 	public final fun component5 ()Ljava/lang/Double;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$NumberProperty;
-	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/ElicitationPropertySchema$NumberProperty;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;ILjava/lang/Object;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$NumberProperty;
+	public final fun component6 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$NumberProperty;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/ElicitationPropertySchema$NumberProperty;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;Ljava/lang/Double;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$NumberProperty;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDefault ()Ljava/lang/Double;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getMaximum ()Ljava/lang/Double;
 	public final fun getMinimum ()Ljava/lang/Double;
 	public final fun getTitle ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -2093,9 +2101,10 @@ public final class com/agentclientprotocol/model/ElicitationPropertySchema$Numbe
 public final class com/agentclientprotocol/model/ElicitationPropertySchema$StringProperty : com/agentclientprotocol/model/ElicitationPropertySchema {
 	public static final field Companion Lcom/agentclientprotocol/model/ElicitationPropertySchema$StringProperty$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/agentclientprotocol/model/StringFormat;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/agentclientprotocol/model/StringFormat;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/agentclientprotocol/model/StringFormat;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/agentclientprotocol/model/StringFormat;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lkotlinx/serialization/json/JsonElement;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/Integer;
 	public final fun component4 ()Ljava/lang/Integer;
@@ -2104,8 +2113,8 @@ public final class com/agentclientprotocol/model/ElicitationPropertySchema$Strin
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/util/List;
 	public final fun component9 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/agentclientprotocol/model/StringFormat;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$StringProperty;
-	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/ElicitationPropertySchema$StringProperty;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/agentclientprotocol/model/StringFormat;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$StringProperty;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/agentclientprotocol/model/StringFormat;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$StringProperty;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/ElicitationPropertySchema$StringProperty;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Lcom/agentclientprotocol/model/StringFormat;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/ElicitationPropertySchema$StringProperty;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDefault ()Ljava/lang/String;
 	public final fun getDescription ()Ljava/lang/String;
@@ -2116,6 +2125,7 @@ public final class com/agentclientprotocol/model/ElicitationPropertySchema$Strin
 	public final fun getOneOf ()Ljava/util/List;
 	public final fun getPattern ()Ljava/lang/String;
 	public final fun getTitle ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/Elicitation.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/Elicitation.kt
@@ -254,7 +254,7 @@ public data class MultiSelectPropertySchema(
 @UnstableApi
 @Serializable
 @JsonClassDiscriminator("type")
-public sealed class ElicitationPropertySchema {
+public sealed class ElicitationPropertySchema : AcpWithMeta {
     @Serializable
     @SerialName("string")
     public data class StringProperty(
@@ -266,7 +266,8 @@ public sealed class ElicitationPropertySchema {
         val format: StringFormat? = null,
         val default: String? = null,
         @SerialName("enum") val enumValues: List<String>? = null,
-        @SerialName("oneOf") val oneOf: List<EnumOption>? = null
+        @SerialName("oneOf") val oneOf: List<EnumOption>? = null,
+        override val _meta: JsonElement? = null
     ) : ElicitationPropertySchema()
 
     @Serializable
@@ -276,7 +277,8 @@ public sealed class ElicitationPropertySchema {
         val description: String? = null,
         val minimum: Double? = null,
         val maximum: Double? = null,
-        val default: Double? = null
+        val default: Double? = null,
+        override val _meta: JsonElement? = null
     ) : ElicitationPropertySchema()
 
     @Serializable
@@ -286,7 +288,8 @@ public sealed class ElicitationPropertySchema {
         val description: String? = null,
         val minimum: Long? = null,
         val maximum: Long? = null,
-        val default: Long? = null
+        val default: Long? = null,
+        override val _meta: JsonElement? = null
     ) : ElicitationPropertySchema()
 
     @Serializable
@@ -294,7 +297,8 @@ public sealed class ElicitationPropertySchema {
     public data class BooleanProperty(
         val title: String? = null,
         val description: String? = null,
-        val default: Boolean? = null
+        val default: Boolean? = null,
+        override val _meta: JsonElement? = null
     ) : ElicitationPropertySchema()
 
     @Serializable
@@ -305,7 +309,8 @@ public sealed class ElicitationPropertySchema {
         val minItems: Long? = null,
         val maxItems: Long? = null,
         val items: MultiSelectItems,
-        val default: List<String>? = null
+        val default: List<String>? = null,
+        override val _meta: JsonElement? = null
     ) : ElicitationPropertySchema()
 }
 

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/ElicitationSerializationTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/ElicitationSerializationTest.kt
@@ -5,6 +5,7 @@ import com.agentclientprotocol.rpc.ACPJson
 import com.agentclientprotocol.rpc.RequestId
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -308,6 +309,38 @@ class ElicitationSerializationTest {
         val stringProp = roundtripped.properties["color"]
         assertIs<ElicitationPropertySchema.StringProperty>(stringProp)
         assertEquals(3, stringProp.enumValues!!.size)
+    }
+
+    @Test
+    fun `schema property preserves meta`() {
+        val schema = ElicitationSchema(
+            properties = mapOf(
+                "color__other1" to ElicitationPropertySchema.StringProperty(
+                    title = "Other",
+                    _meta = JsonObject(
+                        mapOf(
+                            "codex" to JsonObject(
+                                mapOf(
+                                    "questionId" to JsonPrimitive("color"),
+                                    "isOtherAnswer" to JsonPrimitive(true)
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val json = ACPJson.encodeToString(ElicitationSchema.serializer(), schema)
+        val jsonObj = ACPJson.decodeFromString(JsonObject.serializer(), json)
+        val meta = jsonObj["properties"]!!.jsonObject["color__other1"]!!.jsonObject["_meta"]!!.jsonObject
+
+        assertTrue(meta["codex"]!!.jsonObject["isOtherAnswer"]!!.jsonPrimitive.boolean)
+
+        val roundtripped = ACPJson.decodeFromString(ElicitationSchema.serializer(), json)
+        val stringProp = roundtripped.properties["color__other1"]
+        assertIs<ElicitationPropertySchema.StringProperty>(stringProp)
+        assertTrue(stringProp._meta!!.jsonObject["codex"]!!.jsonObject["isOtherAnswer"]!!.jsonPrimitive.boolean)
     }
 
     @Test


### PR DESCRIPTION
## Why
AIR/Codex needs to identify custom-answer elicitation fields from provider metadata instead of guessing from field names or descriptions. The typed Kotlin schema model currently drops `_meta` on elicitation properties, so clients cannot consume those provider-specific annotations after deserialization.

## What changed
- Make `ElicitationPropertySchema` implement `AcpWithMeta`.
- Add `_meta: JsonElement?` to each typed elicitation property variant so unknown provider annotations survive JSON encode/decode.
- Update the API dump for the new public constructor/API surface.

## Tests
- Added `schema property preserves meta` to `ElicitationSerializationTest`.
- The test covers serializing a Codex-style custom-answer marker into a property `_meta` object and deserializing it back on the typed `StringProperty`.

```sh
JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :acp-model:jvmTest --tests com.agentclientprotocol.model.ElicitationSerializationTest :acp-model:apiCheck
```