### PR TITLE
Increment sdk version to 0.28.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 private val buildNumber: String? = System.getenv("GITHUB_RUN_NUMBER")
 private val isReleasePublication = System.getenv("RELEASE_PUBLICATION")?.toBoolean() ?: false
 
-private val baseVersion = "0.26.0"
+private val baseVersion = "0.28.1"
 
 allprojects {
     group = "com.agentclientprotocol"


### PR DESCRIPTION
Bump `baseVersion` from 0.26.0 to 0.28.1 ahead of the v0.28.1 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)