### PR TITLE
Fix request cancellation wire method

### DIFF
--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/Methods.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/Methods.kt
@@ -37,7 +37,7 @@ public open class AcpMethod(public val methodName: MethodName) {
             where TNotification : AcpNotification, TNotification : AcpWithSessionId
 
     public object MetaMethods {
-        public object CancelRequest : AcpNotificationMethod<CancelRequestNotification>("\$/cancelRequest", CancelRequestNotification.serializer())
+        public object CancelRequest : AcpNotificationMethod<CancelRequestNotification>("\$/cancel_request", CancelRequestNotification.serializer())
     }
 
     public object AgentMethods {

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/AcpMethodTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/AcpMethodTest.kt
@@ -1,0 +1,12 @@
+package com.agentclientprotocol.model
+
+import com.agentclientprotocol.rpc.MethodName
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AcpMethodTest {
+    @Test
+    fun `cancel request uses ACP wire method name`() {
+        assertEquals(MethodName("\$/cancel_request"), AcpMethod.MetaMethods.CancelRequest.methodName)
+    }
+}


### PR DESCRIPTION
### Why

ACP defines request cancellation as `$/cancel_request`, but the SDK used the obsolete draft spelling `$/cancelRequest`. This prevented wire-compatible cancellation with implementations following the current specification.

### What changed

- Update `AcpMethod.MetaMethods.CancelRequest` to use `$/cancel_request`.
- Add a common model regression test for the exact wire method name.

### Tests

- `./gradlew :acp-model:jvmTest`
- `./gradlew :acp-ktor-test:jvmTest`
- `./gradlew check` was attempted locally; iOS linking requires full Xcode, which is not installed on this machine.