### PR TITLE
Add stable session/delete support

### DIFF
--- a/acp-ktor-test/src/commonTest/kotlin/com/agentclientprotocol/SimpleAgentTest.kt
+++ b/acp-ktor-test/src/commonTest/kotlin/com/agentclientprotocol/SimpleAgentTest.kt
@@ -9,10 +9,14 @@ import com.agentclientprotocol.common.Event
 import com.agentclientprotocol.common.SessionCreationParameters
 import com.agentclientprotocol.framework.ProtocolDriver
 import com.agentclientprotocol.model.*
+import com.agentclientprotocol.protocol.JsonRpcException
 import com.agentclientprotocol.protocol.invoke
+import com.agentclientprotocol.rpc.JsonRpcErrorCode
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import kotlin.test.*
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -1624,6 +1628,65 @@ abstract class SimpleAgentTest(protocolDriver: ProtocolDriver) : ProtocolDriver 
             postInitializeDeferred.await()
         }
         assertContentEquals(expectedMessages, receivedMessages)
+    }
+
+    @Test
+    fun `session delete capability and method are wired through client api`() = testWithProtocols { clientProtocol, agentProtocol ->
+        val sessionId = SessionId("session-to-delete")
+        val requestMeta = buildJsonObject { put("request", JsonPrimitive("history")) }
+        val responseMeta = buildJsonObject { put("deleted", JsonPrimitive(true)) }
+        var deletedSessionId: SessionId? = null
+        var receivedMeta: JsonElement? = null
+
+        val client = Client(protocol = clientProtocol)
+        Agent(protocol = agentProtocol, agentSupport = object : AgentSupport {
+            override suspend fun initialize(clientInfo: ClientInfo): AgentInfo {
+                return AgentInfo(
+                    clientInfo.protocolVersion,
+                    capabilities = AgentCapabilities(
+                        sessionCapabilities = SessionCapabilities(delete = SessionDeleteCapabilities())
+                    )
+                )
+            }
+
+            override suspend fun deleteSession(sessionId: SessionId, _meta: JsonElement?): DeleteSessionResponse {
+                deletedSessionId = sessionId
+                receivedMeta = _meta
+                return DeleteSessionResponse(_meta = responseMeta)
+            }
+
+            override suspend fun createSession(sessionParameters: SessionCreationParameters): AgentSession {
+                TODO("Not needed for session delete test")
+            }
+        })
+
+        val agentInfo = client.initialize(ClientInfo(protocolVersion = LATEST_PROTOCOL_VERSION))
+        assertNotNull(agentInfo.capabilities.sessionCapabilities.delete)
+
+        val response = client.deleteSession(sessionId, requestMeta)
+
+        assertEquals(sessionId, deletedSessionId)
+        assertEquals(requestMeta, receivedMeta)
+        assertEquals(responseMeta, response._meta)
+    }
+
+    @Test
+    fun `session delete defaults to method not found when unsupported`() = testWithProtocols { clientProtocol, agentProtocol ->
+        val client = Client(protocol = clientProtocol)
+        Agent(protocol = agentProtocol, agentSupport = object : AgentSupport {
+            override suspend fun initialize(clientInfo: ClientInfo): AgentInfo = AgentInfo(clientInfo.protocolVersion)
+
+            override suspend fun createSession(sessionParameters: SessionCreationParameters): AgentSession {
+                TODO("Not needed for session delete test")
+            }
+        })
+
+        client.initialize(ClientInfo(protocolVersion = LATEST_PROTOCOL_VERSION))
+
+        val exception = assertFailsWith<JsonRpcException> {
+            client.deleteSession(SessionId("unknown-session"))
+        }
+        assertEquals(JsonRpcErrorCode.METHOD_NOT_FOUND.code, exception.code)
     }
 
 

--- a/acp-model/api/acp-model.api
+++ b/acp-model/api/acp-model.api
@@ -147,6 +147,10 @@ public final class com/agentclientprotocol/model/AcpMethod$AgentMethods$SessionC
 	public static final field INSTANCE Lcom/agentclientprotocol/model/AcpMethod$AgentMethods$SessionClose;
 }
 
+public final class com/agentclientprotocol/model/AcpMethod$AgentMethods$SessionDelete : com/agentclientprotocol/model/AcpMethod$AcpRequestResponseMethod {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/AcpMethod$AgentMethods$SessionDelete;
+}
+
 public final class com/agentclientprotocol/model/AcpMethod$AgentMethods$SessionFork : com/agentclientprotocol/model/AcpMethod$AcpSessionRequestResponseMethod {
 	public static final field INSTANCE Lcom/agentclientprotocol/model/AcpMethod$AgentMethods$SessionFork;
 }
@@ -1415,6 +1419,65 @@ public final synthetic class com/agentclientprotocol/model/CreateTerminalRespons
 }
 
 public final class com/agentclientprotocol/model/CreateTerminalResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/DeleteSessionRequest : com/agentclientprotocol/model/AcpRequest, com/agentclientprotocol/model/AcpWithSessionId {
+	public static final field Companion Lcom/agentclientprotocol/model/DeleteSessionRequest$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-7EW-EgU ()Ljava/lang/String;
+	public final fun component2 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy-HxD9utI (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/DeleteSessionRequest;
+	public static synthetic fun copy-HxD9utI$default (Lcom/agentclientprotocol/model/DeleteSessionRequest;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/DeleteSessionRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getSessionId-7EW-EgU ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/DeleteSessionRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/DeleteSessionRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/DeleteSessionRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/DeleteSessionRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/DeleteSessionRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/DeleteSessionResponse : com/agentclientprotocol/model/AcpResponse {
+	public static final field Companion Lcom/agentclientprotocol/model/DeleteSessionResponse$Companion;
+	public fun <init> ()V
+	public fun <init> (Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/DeleteSessionResponse;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/DeleteSessionResponse;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/DeleteSessionResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/DeleteSessionResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/DeleteSessionResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/DeleteSessionResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/DeleteSessionResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/DeleteSessionResponse$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -5585,19 +5648,21 @@ public final class com/agentclientprotocol/model/SessionAdditionalDirectoriesCap
 public final class com/agentclientprotocol/model/SessionCapabilities : com/agentclientprotocol/model/AcpWithMeta {
 	public static final field Companion Lcom/agentclientprotocol/model/SessionCapabilities$Companion;
 	public fun <init> ()V
-	public fun <init> (Lcom/agentclientprotocol/model/SessionForkCapabilities;Lcom/agentclientprotocol/model/SessionListCapabilities;Lcom/agentclientprotocol/model/SessionResumeCapabilities;Lcom/agentclientprotocol/model/SessionCloseCapabilities;Lcom/agentclientprotocol/model/SessionAdditionalDirectoriesCapabilities;Lkotlinx/serialization/json/JsonElement;)V
-	public synthetic fun <init> (Lcom/agentclientprotocol/model/SessionForkCapabilities;Lcom/agentclientprotocol/model/SessionListCapabilities;Lcom/agentclientprotocol/model/SessionResumeCapabilities;Lcom/agentclientprotocol/model/SessionCloseCapabilities;Lcom/agentclientprotocol/model/SessionAdditionalDirectoriesCapabilities;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/agentclientprotocol/model/SessionForkCapabilities;Lcom/agentclientprotocol/model/SessionListCapabilities;Lcom/agentclientprotocol/model/SessionResumeCapabilities;Lcom/agentclientprotocol/model/SessionDeleteCapabilities;Lcom/agentclientprotocol/model/SessionCloseCapabilities;Lcom/agentclientprotocol/model/SessionAdditionalDirectoriesCapabilities;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Lcom/agentclientprotocol/model/SessionForkCapabilities;Lcom/agentclientprotocol/model/SessionListCapabilities;Lcom/agentclientprotocol/model/SessionResumeCapabilities;Lcom/agentclientprotocol/model/SessionDeleteCapabilities;Lcom/agentclientprotocol/model/SessionCloseCapabilities;Lcom/agentclientprotocol/model/SessionAdditionalDirectoriesCapabilities;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/agentclientprotocol/model/SessionForkCapabilities;
 	public final fun component2 ()Lcom/agentclientprotocol/model/SessionListCapabilities;
 	public final fun component3 ()Lcom/agentclientprotocol/model/SessionResumeCapabilities;
-	public final fun component4 ()Lcom/agentclientprotocol/model/SessionCloseCapabilities;
-	public final fun component5 ()Lcom/agentclientprotocol/model/SessionAdditionalDirectoriesCapabilities;
-	public final fun component6 ()Lkotlinx/serialization/json/JsonElement;
-	public final fun copy (Lcom/agentclientprotocol/model/SessionForkCapabilities;Lcom/agentclientprotocol/model/SessionListCapabilities;Lcom/agentclientprotocol/model/SessionResumeCapabilities;Lcom/agentclientprotocol/model/SessionCloseCapabilities;Lcom/agentclientprotocol/model/SessionAdditionalDirectoriesCapabilities;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/SessionCapabilities;
-	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/SessionCapabilities;Lcom/agentclientprotocol/model/SessionForkCapabilities;Lcom/agentclientprotocol/model/SessionListCapabilities;Lcom/agentclientprotocol/model/SessionResumeCapabilities;Lcom/agentclientprotocol/model/SessionCloseCapabilities;Lcom/agentclientprotocol/model/SessionAdditionalDirectoriesCapabilities;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/SessionCapabilities;
+	public final fun component4 ()Lcom/agentclientprotocol/model/SessionDeleteCapabilities;
+	public final fun component5 ()Lcom/agentclientprotocol/model/SessionCloseCapabilities;
+	public final fun component6 ()Lcom/agentclientprotocol/model/SessionAdditionalDirectoriesCapabilities;
+	public final fun component7 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Lcom/agentclientprotocol/model/SessionForkCapabilities;Lcom/agentclientprotocol/model/SessionListCapabilities;Lcom/agentclientprotocol/model/SessionResumeCapabilities;Lcom/agentclientprotocol/model/SessionDeleteCapabilities;Lcom/agentclientprotocol/model/SessionCloseCapabilities;Lcom/agentclientprotocol/model/SessionAdditionalDirectoriesCapabilities;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/SessionCapabilities;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/SessionCapabilities;Lcom/agentclientprotocol/model/SessionForkCapabilities;Lcom/agentclientprotocol/model/SessionListCapabilities;Lcom/agentclientprotocol/model/SessionResumeCapabilities;Lcom/agentclientprotocol/model/SessionDeleteCapabilities;Lcom/agentclientprotocol/model/SessionCloseCapabilities;Lcom/agentclientprotocol/model/SessionAdditionalDirectoriesCapabilities;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/SessionCapabilities;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAdditionalDirectories ()Lcom/agentclientprotocol/model/SessionAdditionalDirectoriesCapabilities;
 	public final fun getClose ()Lcom/agentclientprotocol/model/SessionCloseCapabilities;
+	public final fun getDelete ()Lcom/agentclientprotocol/model/SessionDeleteCapabilities;
 	public final fun getFork ()Lcom/agentclientprotocol/model/SessionForkCapabilities;
 	public final fun getList ()Lcom/agentclientprotocol/model/SessionListCapabilities;
 	public final fun getResume ()Lcom/agentclientprotocol/model/SessionResumeCapabilities;
@@ -6039,6 +6104,35 @@ public final synthetic class com/agentclientprotocol/model/SessionConfigValueId$
 }
 
 public final class com/agentclientprotocol/model/SessionConfigValueId$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/SessionDeleteCapabilities : com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/SessionDeleteCapabilities$Companion;
+	public fun <init> ()V
+	public fun <init> (Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/SessionDeleteCapabilities;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/SessionDeleteCapabilities;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/SessionDeleteCapabilities;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/SessionDeleteCapabilities$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/SessionDeleteCapabilities$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/SessionDeleteCapabilities;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/SessionDeleteCapabilities;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/SessionDeleteCapabilities$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/Capabilities.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/Capabilities.kt
@@ -147,6 +147,16 @@ public data class SessionResumeCapabilities(
 ) : AcpWithMeta
 
 /**
+ * Capabilities for deleting sessions from history.
+ *
+ * By supplying `{}` it means that the agent supports the `session/delete` method.
+ */
+@Serializable
+public data class SessionDeleteCapabilities(
+    override val _meta: JsonElement? = null
+) : AcpWithMeta
+
+/**
  * **UNSTABLE**
  *
  * This capability is not part of the spec yet, and may be removed or changed at any point.
@@ -186,6 +196,7 @@ public data class SessionCapabilities(
     val fork: SessionForkCapabilities? = null,
     val list: SessionListCapabilities? = null,
     val resume: SessionResumeCapabilities? = null,
+    val delete: SessionDeleteCapabilities? = null,
     @property:UnstableApi
     val close: SessionCloseCapabilities? = null,
     @property:UnstableApi

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/Methods.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/Methods.kt
@@ -54,6 +54,7 @@ public open class AcpMethod(public val methodName: MethodName) {
         public object ProvidersDisable : AcpRequestResponseMethod<DisableProvidersRequest, DisableProvidersResponse>("providers/disable", DisableProvidersRequest.serializer(), DisableProvidersResponse.serializer())
         public object SessionNew : AcpRequestResponseMethod<NewSessionRequest, NewSessionResponse>("session/new", NewSessionRequest.serializer(), NewSessionResponse.serializer())
         public object SessionLoad : AcpRequestResponseMethod<LoadSessionRequest, LoadSessionResponse>("session/load", LoadSessionRequest.serializer(), LoadSessionResponse.serializer())
+        public object SessionDelete : AcpRequestResponseMethod<DeleteSessionRequest, DeleteSessionResponse>("session/delete", DeleteSessionRequest.serializer(), DeleteSessionResponse.serializer())
 
         // session specific
         public object SessionPrompt : AcpSessionRequestResponseMethod<PromptRequest, PromptResponse>("session/prompt", PromptRequest.serializer(), PromptResponse.serializer())

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/Requests.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/Requests.kt
@@ -866,6 +866,23 @@ public data class ReleaseTerminalResponse(
 ) : AcpResponse
 
 /**
+ * Request to delete a session from history.
+ */
+@Serializable
+public data class DeleteSessionRequest(
+    override val sessionId: SessionId,
+    override val _meta: JsonElement? = null
+) : AcpRequest, AcpWithSessionId
+
+/**
+ * Response from deleting a session from history.
+ */
+@Serializable
+public data class DeleteSessionResponse(
+    override val _meta: JsonElement? = null
+) : AcpResponse
+
+/**
  * **UNSTABLE**
  *
  * This capability is not part of the spec yet, and may be removed or changed at any point.

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/CapabilitiesConversions.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/CapabilitiesConversions.kt
@@ -5,6 +5,7 @@ package com.agentclientprotocol.model.v2.conversion
 import com.agentclientprotocol.annotations.UnstableApi
 import com.agentclientprotocol.model.FileSystemCapability
 import com.agentclientprotocol.model.SessionCloseCapabilities
+import com.agentclientprotocol.model.SessionDeleteCapabilities
 import com.agentclientprotocol.model.SessionListCapabilities
 import com.agentclientprotocol.model.SessionResumeCapabilities
 import com.agentclientprotocol.model.v2.AgentAuthCapabilities
@@ -19,6 +20,7 @@ import com.agentclientprotocol.model.v2.PromptCapabilities
 import com.agentclientprotocol.model.v2.PromptEmbeddedContextCapabilities
 import com.agentclientprotocol.model.v2.PromptImageCapabilities
 import com.agentclientprotocol.model.v2.SessionCapabilities
+import com.agentclientprotocol.model.v2.SessionDeleteCapabilities as V2SessionDeleteCapabilities
 import com.agentclientprotocol.model.AgentAuthCapabilities as V1AgentAuthCapabilities
 import com.agentclientprotocol.model.AgentCapabilities as V1AgentCapabilities
 import com.agentclientprotocol.model.AuthCapabilities as V1AuthCapabilities
@@ -136,17 +138,16 @@ public data class V1SessionCapabilityParts(
  * markers for the methods that became baseline — `list`, `resume`, `close` and
  * `loadSession` — are synthesized here.
  *
- * @throws ProtocolConversionException if [SessionCapabilities.delete] is set — the v1
- * Kotlin model has no `delete` field — or if a nested capability has no v1 representation
+ * @throws ProtocolConversionException if a nested capability has no v1 representation
  */
 @UnstableApi
 public fun SessionCapabilities.toV1Parts(): V1SessionCapabilityParts {
-    if (delete != null) throw unrepresentableV2Field("SessionCapabilities", "delete")
     return V1SessionCapabilityParts(
         sessionCapabilities = V1SessionCapabilities(
             fork = fork,
             list = SessionListCapabilities(),
             resume = SessionResumeCapabilities(),
+            delete = delete?.let { SessionDeleteCapabilities(_meta = it._meta) },
             close = SessionCloseCapabilities(),
             additionalDirectories = additionalDirectories,
             _meta = _meta,
@@ -189,7 +190,7 @@ public fun SessionCapabilities.Companion.fromV1(
     return SessionCapabilities(
         prompt = promptCapabilities.toV2(),
         mcp = mcpCapabilities.toV2(),
-        delete = null,
+        delete = sessionCapabilities.delete?.let { V2SessionDeleteCapabilities(_meta = it._meta) },
         additionalDirectories = sessionCapabilities.additionalDirectories,
         fork = sessionCapabilities.fork,
         _meta = sessionCapabilities._meta,

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/SessionDeleteSerializationTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/SessionDeleteSerializationTest.kt
@@ -1,0 +1,67 @@
+package com.agentclientprotocol.model
+
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class SessionDeleteSerializationTest {
+
+    @Test
+    fun `agent capabilities round trip session delete marker with meta`() {
+        val payload = """
+            {
+              "sessionCapabilities": {
+                "delete": {
+                  "_meta": {"source": "history"}
+                }
+              }
+            }
+        """.trimIndent()
+
+        val decoded = ACPJson.decodeFromString(AgentCapabilities.serializer(), payload)
+        val roundTripped = ACPJson.decodeFromString(
+            AgentCapabilities.serializer(),
+            ACPJson.encodeToString(AgentCapabilities.serializer(), decoded),
+        )
+
+        val expectedMeta = buildJsonObject { put("source", JsonPrimitive("history")) }
+        assertEquals(expectedMeta, assertNotNull(decoded.sessionCapabilities.delete)._meta)
+        assertEquals(decoded, roundTripped)
+    }
+
+    @Test
+    fun `session delete marker remains absent when not advertised`() {
+        val decoded = ACPJson.decodeFromString(
+            AgentCapabilities.serializer(),
+            """{"sessionCapabilities": {}}""",
+        )
+
+        assertNull(decoded.sessionCapabilities.delete)
+    }
+
+    @Test
+    fun `delete session request round trips session id and meta`() {
+        val request = DeleteSessionRequest(
+            sessionId = SessionId("session-1"),
+            _meta = buildJsonObject { put("request", JsonPrimitive(42)) },
+        )
+
+        val encoded = ACPJson.encodeToString(DeleteSessionRequest.serializer(), request)
+
+        assertEquals(request, ACPJson.decodeFromString(DeleteSessionRequest.serializer(), encoded))
+    }
+
+    @Test
+    fun `delete session response serializes as empty object by default`() {
+        assertEquals("{}", ACPJson.encodeToString(DeleteSessionResponse.serializer(), DeleteSessionResponse()))
+    }
+
+    @Test
+    fun `session delete method uses stable wire name`() {
+        assertEquals("session/delete", AcpMethod.AgentMethods.SessionDelete.methodName.name)
+    }
+}

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/CapabilitiesConversionTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/CapabilitiesConversionTest.kt
@@ -34,6 +34,7 @@ import com.agentclientprotocol.model.InitializeResponse as V1InitializeResponse
 import com.agentclientprotocol.model.McpCapabilities as V1McpCapabilities
 import com.agentclientprotocol.model.PromptCapabilities as V1PromptCapabilities
 import com.agentclientprotocol.model.SessionCapabilities as V1SessionCapabilities
+import com.agentclientprotocol.model.SessionDeleteCapabilities as V1SessionDeleteCapabilities
 
 class CapabilitiesConversionTest {
 
@@ -121,12 +122,28 @@ class CapabilitiesConversionTest {
     }
 
     @Test
-    fun `converting v2 session delete support to v1 fails because v1 has no such field`() {
-        val exception = assertFailsWith<ProtocolConversionException> {
-            SessionCapabilities(delete = SessionDeleteCapabilities()).toV1Parts()
-        }
+    fun `session delete capability round trips between v1 and v2 with meta`() {
+        val meta = buildJsonObject { put("k", JsonPrimitive("v")) }
+        val v2 = baselineV2AgentCapabilities().session!!.copy(
+            delete = SessionDeleteCapabilities(_meta = meta),
+        )
 
-        assertEquals("v2 SessionCapabilities.delete cannot be represented in v1", exception.message)
+        val parts = v2.toV1Parts()
+        val roundTripped = SessionCapabilities.fromV1(
+            sessionCapabilities = parts.sessionCapabilities,
+            promptCapabilities = parts.promptCapabilities,
+            loadSession = parts.loadSession,
+            mcpCapabilities = parts.mcpCapabilities,
+        )
+
+        assertEquals(V1SessionDeleteCapabilities(_meta = meta), parts.sessionCapabilities.delete)
+        assertEquals(v2, roundTripped)
+    }
+
+    @Test
+    fun `session delete capability remains absent across v1 and v2 conversions`() {
+        assertNull(baselineV2AgentCapabilities().toV1().sessionCapabilities.delete)
+        assertNull(baselineV1AgentCapabilities().toV2().session!!.delete)
     }
 
     @Test

--- a/acp/api/acp.api
+++ b/acp/api/acp.api
@@ -89,6 +89,8 @@ public abstract interface class com/agentclientprotocol/agent/AgentSupport {
 	public fun createNesSession (Lcom/agentclientprotocol/model/StartNesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun createNesSession$suspendImpl (Lcom/agentclientprotocol/agent/AgentSupport;Lcom/agentclientprotocol/model/StartNesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun createSession (Lcom/agentclientprotocol/common/SessionCreationParameters;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun deleteSession-nk3TnMc (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteSession-nk3TnMc$suspendImpl (Lcom/agentclientprotocol/agent/AgentSupport;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun disableProvider (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun disableProvider$suspendImpl (Lcom/agentclientprotocol/agent/AgentSupport;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun forkSession-nk3TnMc (Ljava/lang/String;Lcom/agentclientprotocol/common/SessionCreationParameters;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -111,6 +113,7 @@ public abstract interface class com/agentclientprotocol/agent/AgentSupport {
 public final class com/agentclientprotocol/agent/AgentSupport$DefaultImpls {
 	public static fun authenticate-fMnwWJU (Lcom/agentclientprotocol/agent/AgentSupport;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun createNesSession (Lcom/agentclientprotocol/agent/AgentSupport;Lcom/agentclientprotocol/model/StartNesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun deleteSession-nk3TnMc (Lcom/agentclientprotocol/agent/AgentSupport;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun disableProvider (Lcom/agentclientprotocol/agent/AgentSupport;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun forkSession-nk3TnMc (Lcom/agentclientprotocol/agent/AgentSupport;Ljava/lang/String;Lcom/agentclientprotocol/common/SessionCreationParameters;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun listProviders (Lcom/agentclientprotocol/agent/AgentSupport;Lkotlinx/serialization/json/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -164,6 +167,8 @@ public final class com/agentclientprotocol/client/Client {
 	public synthetic fun <init> (Lcom/agentclientprotocol/protocol/Protocol;Lcom/agentclientprotocol/client/GlobalElicitationHandler;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun authenticate-fMnwWJU (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun authenticate-fMnwWJU$default (Lcom/agentclientprotocol/client/Client;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun deleteSession-nk3TnMc (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteSession-nk3TnMc$default (Lcom/agentclientprotocol/client/Client;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun disableProvider (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun disableProvider$default (Lcom/agentclientprotocol/client/Client;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun forkSession-wPMwmcM (Ljava/lang/String;Lcom/agentclientprotocol/common/SessionCreationParameters;Lcom/agentclientprotocol/client/ClientOperationsFactory;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/acp/src/commonMain/kotlin/com/agentclientprotocol/agent/Agent.kt
+++ b/acp/src/commonMain/kotlin/com/agentclientprotocol/agent/Agent.kt
@@ -184,6 +184,10 @@ public class Agent(
             sequenceFactory = { p -> agentSupport.listSessions(p.cwd, p.additionalDirectories, p._meta) }
         )
 
+        protocol.setRequestHandler(AcpMethod.AgentMethods.SessionDelete) { params: DeleteSessionRequest ->
+            return@setRequestHandler agentSupport.deleteSession(params.sessionId, params._meta)
+        }
+
         protocol.setRequestHandler(AcpMethod.AgentMethods.SessionNew) { params: NewSessionRequest ->
             val sessionParameters = SessionCreationParameters(params.cwd, params.mcpServers, params.additionalDirectories, params._meta)
             val session = createSession(sessionParameters) { agentSupport.createSession(it) }

--- a/acp/src/commonMain/kotlin/com/agentclientprotocol/agent/AgentSupport.kt
+++ b/acp/src/commonMain/kotlin/com/agentclientprotocol/agent/AgentSupport.kt
@@ -5,6 +5,7 @@ import com.agentclientprotocol.client.ClientInfo
 import com.agentclientprotocol.common.SessionCreationParameters
 import com.agentclientprotocol.model.AuthMethodId
 import com.agentclientprotocol.model.AuthenticateResponse
+import com.agentclientprotocol.model.DeleteSessionResponse
 import com.agentclientprotocol.model.DisableProvidersResponse
 import com.agentclientprotocol.model.ListProvidersResponse
 import com.agentclientprotocol.model.LlmProtocol
@@ -13,6 +14,7 @@ import com.agentclientprotocol.model.SessionId
 import com.agentclientprotocol.model.SessionInfo
 import com.agentclientprotocol.model.SetProvidersResponse
 import com.agentclientprotocol.model.StartNesRequest
+import com.agentclientprotocol.protocol.jsonRpcMethodNotFound
 import kotlinx.serialization.json.JsonElement
 
 public interface AgentSupport {
@@ -125,6 +127,20 @@ public interface AgentSupport {
     @UnstableApi
     public suspend fun listSessions(cwd: String?, additionalDirectories: List<String>?, _meta: JsonElement?): Sequence<SessionInfo> {
         throw NotImplementedError("listSessions is not implemented. The capability is declared in AgentCapabilities.sessionCapabilities.list")
+    }
+
+    /**
+     * Deletes a session from history.
+     *
+     * Implementations advertising this capability must succeed when the session id is unknown
+     * or has already been deleted.
+     *
+     * @param sessionId the id of the session to delete
+     * @param _meta optional metadata
+     * @return a [DeleteSessionResponse] indicating the deletion result
+     */
+    public suspend fun deleteSession(sessionId: SessionId, _meta: JsonElement?): DeleteSessionResponse {
+        jsonRpcMethodNotFound("deleteSession is not implemented. The capability is declared in AgentCapabilities.sessionCapabilities.delete")
     }
 
     /**

--- a/acp/src/commonMain/kotlin/com/agentclientprotocol/client/Client.kt
+++ b/acp/src/commonMain/kotlin/com/agentclientprotocol/client/Client.kt
@@ -416,6 +416,19 @@ public class Client(
     }
 
     /**
+     * Deletes a session from the agent's history.
+     *
+     * This operation does not modify sessions loaded into this client runtime.
+     *
+     * @param sessionId the id of the session to delete
+     * @param _meta optional metadata
+     * @return the agent's [DeleteSessionResponse]
+     */
+    public suspend fun deleteSession(sessionId: SessionId, _meta: JsonElement? = null): DeleteSessionResponse {
+        return AcpMethod.AgentMethods.SessionDelete(protocol, DeleteSessionRequest(sessionId, _meta))
+    }
+
+    /**
      * **UNSTABLE**
      *
      * This capability is not part of the spec yet, and may be removed or changed at any point.


### PR DESCRIPTION
### Summary
- add stable `session/delete` capability, request/response models, and JSON-RPC method registration
- wire deletion through `AgentSupport`, `Agent`, and `Client.deleteSession`
- preserve delete capability metadata across stable v1 and unstable v2 conversions and update API baselines

### Testing
- `./gradlew jvmTest apiCheck`
- focused model serialization, capability conversion, and Ktor integration tests
- full all-platform `check` was attempted but is blocked on this machine because the iPhone Simulator SDK is unavailable

### Tracking
- https://youtrack.jetbrains.com/issue/JUNIE-4145