### PR TITLE
Add descriptions to elicitation options

### DIFF
--- a/acp-model/api/acp-model.api
+++ b/acp-model/api/acp-model.api
@@ -2388,16 +2388,21 @@ public final class com/agentclientprotocol/model/EmbeddedResourceResource$TextRe
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/agentclientprotocol/model/EnumOption {
+public final class com/agentclientprotocol/model/EnumOption : com/agentclientprotocol/model/AcpWithMeta {
 	public static final field Companion Lcom/agentclientprotocol/model/EnumOption$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/agentclientprotocol/model/EnumOption;
-	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/EnumOption;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/EnumOption;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/EnumOption;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/EnumOption;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/EnumOption;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
 	public final fun getTitle ()Ljava/lang/String;
 	public final fun getValue ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/Elicitation.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/Elicitation.kt
@@ -98,14 +98,16 @@ public enum class ElicitationUrlOnlyMode {
 // === Property Schemas ===
 
 /**
- * A titled enum option with a const value and human-readable title.
+ * A titled enum option with a const value, human-readable title, optional description, and metadata.
  */
 @UnstableApi
 @Serializable
 public data class EnumOption(
     @SerialName("const") val value: String,
-    val title: String
-)
+    val title: String,
+    val description: String? = null,
+    override val _meta: JsonElement? = null
+) : AcpWithMeta
 
 /**
  * Schema for string properties in an elicitation form.

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/ElicitationSerializationTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/ElicitationSerializationTest.kt
@@ -349,7 +349,7 @@ class ElicitationSerializationTest {
             properties = mapOf(
                 "country" to ElicitationPropertySchema.StringProperty(
                     oneOf = listOf(
-                        EnumOption("us", "United States"),
+                        EnumOption("us", "United States", "Country code for the United States"),
                         EnumOption("uk", "United Kingdom")
                     )
                 )
@@ -366,11 +366,19 @@ class ElicitationSerializationTest {
         assertEquals(2, oneOf.size)
         assertEquals("us", oneOf[0].jsonObject["const"]?.jsonPrimitive?.content)
         assertEquals("United States", oneOf[0].jsonObject["title"]?.jsonPrimitive?.content)
+        assertEquals("Country code for the United States", oneOf[0].jsonObject["description"]?.jsonPrimitive?.content)
+        assertFalse("description" in oneOf[1].jsonObject)
 
         val roundtripped = ACPJson.decodeFromString(ElicitationSchema.serializer(), json)
         val stringProp = roundtripped.properties["country"]
         assertIs<ElicitationPropertySchema.StringProperty>(stringProp)
-        assertEquals(2, stringProp.oneOf!!.size)
+        assertEquals(
+            listOf(
+                EnumOption("us", "United States", "Country code for the United States"),
+                EnumOption("uk", "United Kingdom")
+            ),
+            stringProp.oneOf
+        )
     }
 
     @Test

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ElicitationPropertySchemaTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/ElicitationPropertySchemaTest.kt
@@ -12,6 +12,7 @@ import com.agentclientprotocol.model.v2.conversion.toV2
 import com.agentclientprotocol.rpc.ACPJson
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -52,11 +53,21 @@ class ElicitationPropertySchemaTest {
     @Test
     fun `titled multi-select items are untagged and round-trip`() {
         val schema = ElicitationPropertySchema.ArrayProperty(
-            items = MultiSelectItems.Titled(options = listOf(EnumOption(value = "a", title = "Option A"))),
+            items = MultiSelectItems.Titled(
+                options = listOf(
+                    EnumOption(
+                        value = "a",
+                        title = "Option A",
+                        description = "The first option",
+                        _meta = buildJsonObject { put("icon", "alpha") },
+                    ),
+                    EnumOption(value = "b", title = "Option B"),
+                ),
+            ),
         )
 
         assertEquals(
-            """{"type":"array","items":{"anyOf":[{"const":"a","title":"Option A"}]}}""",
+            """{"type":"array","items":{"anyOf":[{"const":"a","title":"Option A","description":"The first option","_meta":{"icon":"alpha"}},{"const":"b","title":"Option B"}]}}""",
             encode(schema),
         )
         assertEquals(schema, decode(encode(schema)))


### PR DESCRIPTION
### Summary
- add optional human-readable descriptions to shared elicitation enum options
- preserve the existing JSON shape when no description is provided
- cover v1 `oneOf` and v2 multi-select `anyOf` serialization and round trips

### Testing
- `./gradlew :acp-model:jvmTest :acp-model:jsNodeTest :acp-model:wasmJsNodeTest`
- `./gradlew :acp-model:apiCheck`
- `./gradlew :acp-model:compileTestKotlinIosArm64 :acp-model:compileTestKotlinIosSimulatorArm64`

### Notes
- iOS simulator execution was unavailable locally because `xcrun` could not detect Xcode; iOS test compilation passed.