### PR TITLE
Do not report an existing session as missing in getOrCreateSessionHolder

### DIFF
--- a/acp/src/commonMain/kotlin/com/agentclientprotocol/client/Client.kt
+++ b/acp/src/commonMain/kotlin/com/agentclientprotocol/client/Client.kt
@@ -96,24 +96,29 @@ public class Client(
      * Creates a new entry only if there are some currently initializing sessions. Otherwise, throws in the case of missing session.
      */
     private fun getOrCreateSessionHolder(sessionId: SessionId): ClientSessionHolder {
-        val sessionsStorage = _sessions.value
-        val holder = sessionsStorage.sessions[sessionId]
-        if (holder != null) return holder
+        // Fast path for the common case of an already registered session.
+        _sessions.value.sessions[sessionId]?.let { return it }
         var clientSessionHolder: ClientSessionHolder? = null
+        // Every branch below has to look the session up in `currentStorage` rather than rely on the read above:
+        // `_sessions` can change between that read and the CAS, and it can change again between two attempts of
+        // the CAS loop. A session that a concurrent newSession/loadSession registers in such a window - together
+        // with decrementing `initializingSessionsCount` back to zero - would otherwise be reported as missing.
         _sessions.update { currentStorage ->
-            if (currentStorage.initializingSessionsCount > 0) {
-                val existingHolder = currentStorage.sessions[sessionId]
-                if (existingHolder != null) {
+            val existingHolder = currentStorage.sessions[sessionId]
+            when {
+                existingHolder != null -> {
                     clientSessionHolder = existingHolder
                     currentStorage
-                } else {
+                }
+                currentStorage.initializingSessionsCount > 0 -> {
                     val newHolder = ClientSessionHolder()
                     clientSessionHolder = newHolder
                     currentStorage.copy(sessions = currentStorage.sessions.put(sessionId, newHolder))
                 }
-            } else {
-                clientSessionHolder = null
-                currentStorage
+                else -> {
+                    clientSessionHolder = null
+                    currentStorage
+                }
             }
         }
         return clientSessionHolder ?: acpFail("Session $sessionId not found")

--- a/acp/src/jvmTest/kotlin/com/agentclientprotocol/client/ClientSessionUpdateDeliveryTest.kt
+++ b/acp/src/jvmTest/kotlin/com/agentclientprotocol/client/ClientSessionUpdateDeliveryTest.kt
@@ -1,0 +1,161 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.client
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.common.ClientSessionOperations
+import com.agentclientprotocol.common.SessionCreationParameters
+import com.agentclientprotocol.model.AcpMethod
+import com.agentclientprotocol.model.ContentBlock
+import com.agentclientprotocol.model.NewSessionResponse
+import com.agentclientprotocol.model.PermissionOption
+import com.agentclientprotocol.model.RequestPermissionResponse
+import com.agentclientprotocol.model.SessionId
+import com.agentclientprotocol.model.SessionNotification
+import com.agentclientprotocol.model.SessionUpdate
+import com.agentclientprotocol.protocol.Protocol
+import com.agentclientprotocol.rpc.ACPJson
+import com.agentclientprotocol.rpc.JsonRpcMessage
+import com.agentclientprotocol.rpc.JsonRpcNotification
+import com.agentclientprotocol.rpc.JsonRpcRequest
+import com.agentclientprotocol.rpc.JsonRpcResponse
+import com.agentclientprotocol.transport.BaseTransport
+import com.agentclientprotocol.transport.Transport
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.JsonElement
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * An agent may put a `session/update` on the wire immediately after the `session/new` response, so the client
+ * receives both back to back while `newSession` is still returning on another thread. The notification must
+ * still reach the session's operations: the client either queues it on the holder being initialized, or hands
+ * it to the session that has just been registered.
+ *
+ * Getting this wrong used to be observable as `AcpExpectedError: Session <id> not found` logged by the
+ * protocol, plus a silently dropped update, whenever the notification was handled while the concurrent
+ * `newSession` was registering its holder and dropping `initializingSessionsCount` back to zero.
+ */
+class ClientSessionUpdateDeliveryTest {
+    @Test
+    fun `session update sent right after the session new response reaches the session`() {
+        val delivered = atomic(0)
+        // The interleaving is only reachable when the notification is handled while a concurrent newSession is
+        // registering its session, so this is a probabilistic stress test: correct code can never fail it, while
+        // the regression it guards against showed up in roughly one run out of three on a warm 10-core laptop.
+        // Each batch gets a fresh client to keep the session map - and with it the cost of a round - from
+        // growing over the run.
+        repeat(BATCHES) {
+            val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+            try {
+                val transport = EagerUpdateAgentTransport()
+                val protocol = Protocol(scope, transport)
+                protocol.start()
+                transport.start()
+                val client = Client(protocol)
+
+                runBlocking {
+                    // Real parallelism between the protocol read loop and the `newSession` continuation is the
+                    // whole point, so sessions are created off the (single-threaded) runBlocking dispatcher.
+                    withContext(Dispatchers.Default) {
+                        repeat(ROUNDS_PER_BATCH) {
+                            (1..CONCURRENCY).map {
+                                async {
+                                    val update = CompletableUpdate()
+                                    client.newSession(SessionCreationParameters(cwd = ".", mcpServers = emptyList())) { _, _ ->
+                                        update
+                                    }
+                                    if (update.awaitNotification()) delivered.incrementAndGet()
+                                }
+                            }.awaitAll()
+                        }
+                    }
+                }
+            } finally {
+                scope.cancel()
+            }
+        }
+
+        assertEquals(BATCHES * ROUNDS_PER_BATCH * CONCURRENCY, delivered.value, "every session/update must reach its session")
+    }
+
+    private companion object {
+        private const val BATCHES = 60
+        private const val ROUNDS_PER_BATCH = 250
+        private const val CONCURRENCY = 4
+    }
+}
+
+/** Records the single `session/update` the fake agent sends for a session. */
+private class CompletableUpdate : ClientSessionOperations {
+    private val notified = CompletableDeferred<Unit>()
+
+    override suspend fun requestPermissions(
+        toolCall: SessionUpdate.ToolCallUpdate,
+        permissions: List<PermissionOption>,
+        _meta: JsonElement?,
+    ): RequestPermissionResponse = error("not expected in this test")
+
+    override suspend fun notify(notification: SessionUpdate, _meta: JsonElement?) {
+        notified.complete(Unit)
+    }
+
+    suspend fun awaitNotification(): Boolean = withTimeoutOrNull(NOTIFICATION_TIMEOUT) { notified.await() } != null
+
+    private companion object {
+        private val NOTIFICATION_TIMEOUT = 5.seconds
+    }
+}
+
+/**
+ * A minimal agent that answers `session/new` and, without yielding in between, sends one `session/update` for
+ * the session it has just created - the sequence a real agent produces when it reports its available commands
+ * as soon as the session exists.
+ */
+private class EagerUpdateAgentTransport : BaseTransport() {
+    private val sessionCounter = atomic(0)
+
+    override fun start() {
+        _state.value = Transport.State.STARTED
+    }
+
+    override fun close() {
+        _state.value = Transport.State.CLOSING
+        fireClose()
+        _state.value = Transport.State.CLOSED
+    }
+
+    override fun send(message: JsonRpcMessage) {
+        if (message !is JsonRpcRequest || message.method != AcpMethod.AgentMethods.SessionNew.methodName) return
+        val sessionId = SessionId("session-${sessionCounter.incrementAndGet()}")
+        fireMessage(
+            JsonRpcResponse(
+                id = message.id,
+                result = ACPJson.encodeToJsonElement(
+                    AcpMethod.AgentMethods.SessionNew.responseSerializer,
+                    NewSessionResponse(sessionId),
+                ),
+            )
+        )
+        fireMessage(
+            JsonRpcNotification(
+                method = AcpMethod.ClientMethods.SessionUpdate.methodName,
+                params = ACPJson.encodeToJsonElement(
+                    AcpMethod.ClientMethods.SessionUpdate.serializer,
+                    SessionNotification(sessionId, SessionUpdate.AgentMessageChunk(ContentBlock.Text("update"))),
+                ),
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Problem

`Client.getOrCreateSessionHolder` reads the session map once, before entering the `_sessions.update` CAS loop, and the loop's `initializingSessionsCount == 0` branch never consults `currentStorage` again:

```kotlin
val sessionsStorage = _sessions.value
val holder = sessionsStorage.sessions[sessionId]
if (holder != null) return holder            // only existence check
_sessions.update { currentStorage ->
    if (currentStorage.initializingSessionsCount > 0) { /* looks the session up */ }
    else {
        clientSessionHolder = null           // ignores currentStorage.sessions[sessionId]
        currentStorage
    }
}
return clientSessionHolder ?: acpFail("Session $sessionId not found")
```

`_sessions` can change between that read and the CAS, and again between two attempts of the CAS loop. When a `session/update` is handled on the protocol read loop while a concurrent `newSession`/`loadSession` is *both* registering its holder *and* decrementing the counter back to zero, the notification lands in the `else` branch and fails with

```
SEVERE com.agentclientprotocol.protocol.Protocol - Error handling notification MethodName(name=session/update)
com.agentclientprotocol.protocol.AcpExpectedError: Session 714f8c4c-7914-4e11-9d3e-f2d85dfd5a41 not found
	at com.agentclientprotocol.protocol.ProtocolKt.acpFail(Protocol.kt:50)
	at com.agentclientprotocol.client.Client.getOrCreateSessionHolder(Client.kt:119)
	at com.agentclientprotocol.client.Client$9.invokeSuspend(Client.kt:211)
```

even though the session exists. The update is dropped.

## How it shows up

Agents that emit an update as soon as the session exists hit this in the field. With `claude-agent-acp` the `session/new` response and the first `available_commands_update` arrive in the same read:

```
00:20:33,277 OUT session/new
00:20:33,678 IN  id=2 result {"sessionId":"714f8c4c-..."}
00:20:33,678 IN  session/update available_commands_update
00:20:33,682 SEVERE Session 714f8c4c-... not found
00:20:34,182 OUT session/close                            <- +500 ms, the caller's own timeout
```

A sibling probe against the same agent, whose notification happened to arrive 2 ms after the response, was unaffected. The caller here was waiting for `available_commands_update`, so the dropped notification cost it a full grace period and it ended up with an empty command list.

## Fix

Look the session up *inside* the atomic block, so every branch — including a retry after a failed CAS — sees the map as it is at that moment. The read before the loop stays as a fast path for the already-registered case.

## Test

`ClientSessionUpdateDeliveryTest` drives a fake agent that answers `session/new` and, without yielding, sends one `session/update` for the session it just created, with `newSession` running off the protocol read loop's thread.

The interleaving is only reachable under real parallelism, so this is a probabilistic stress test rather than a deterministic one: **correct code can never fail it**, while on `master` it fails in roughly one run out of three on a warm 10-core laptop, always with `AcpExpectedError: Session session-<n> not found` and one lost update. Increasing the attempt count does not help much — the hits cluster rather than distribute uniformly — so it is sized for ~1.7 s.

`:acp:jvmTest`, `:acp-model:jvmTest` and `:acp-ktor-test:jvmTest` pass.