### PR TITLE
Fix notification handler dispatch deadlock

### DIFF
--- a/acp-ktor-test/src/commonTest/kotlin/com/agentclientprotocol/ProtocolTest.kt
+++ b/acp-ktor-test/src/commonTest/kotlin/com/agentclientprotocol/ProtocolTest.kt
@@ -2,18 +2,25 @@ package com.agentclientprotocol
 
 import com.agentclientprotocol.framework.ProtocolDriver
 import com.agentclientprotocol.model.AcpMethod
+import com.agentclientprotocol.model.AcpNotification
 import com.agentclientprotocol.model.AcpRequest
 import com.agentclientprotocol.model.AcpResponse
+import com.agentclientprotocol.model.CancelRequestNotification
 import com.agentclientprotocol.protocol.AcpExpectedError
 import com.agentclientprotocol.protocol.JsonRpcException
 import com.agentclientprotocol.protocol.acpFail
+import com.agentclientprotocol.protocol.jsonRpcRequest
+import com.agentclientprotocol.protocol.sendNotification
 import com.agentclientprotocol.protocol.sendRequest
+import com.agentclientprotocol.protocol.setNotificationHandler
 import com.agentclientprotocol.protocol.setRequestHandler
 import com.agentclientprotocol.rpc.JsonRpcErrorCode
+import com.agentclientprotocol.rpc.RequestId
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestResult
@@ -37,12 +44,15 @@ import kotlin.time.measureTimedValue
 data class TestRequest(val message: String, override val _meta: JsonElement? = null) : AcpRequest
 @Serializable
 data class TestResponse(val message: String, override val _meta: JsonElement? = null) : AcpResponse
+@Serializable
+data class TestNotification(val message: String, override val _meta: JsonElement? = null) : AcpNotification
 
 abstract class ProtocolTest(protocolDriver: ProtocolDriver) : ProtocolDriver by protocolDriver {
     val cancellationMessage = "Cancelled from test"
 
     companion object {
         object TestMethod : AcpMethod.AcpRequestResponseMethod<TestRequest, TestResponse>("test/testRequest", TestRequest.serializer(), TestResponse.serializer())
+        object TestNotificationMethod : AcpMethod.AcpNotificationMethod<TestNotification>("test/testNotification", TestNotification.serializer())
     }
 
     @Test
@@ -53,6 +63,180 @@ abstract class ProtocolTest(protocolDriver: ProtocolDriver) : ProtocolDriver by 
 
         val response = clientProtocol.sendRequest(TestMethod, TestRequest("Test"))
         assertEquals("Test", response.message)
+    }
+
+    @Test
+    fun `response is processed while notification handler is suspended`() = testWithProtocols { clientProtocol, agentProtocol ->
+        val notificationStarted = CompletableDeferred<Unit>()
+        val releaseNotification = CompletableDeferred<Unit>()
+        val notificationCompleted = CompletableDeferred<Unit>()
+        val responseCompleted = CompletableDeferred<TestResponse>()
+
+        clientProtocol.setNotificationHandler(TestNotificationMethod) {
+            notificationStarted.complete(Unit)
+            releaseNotification.await()
+            notificationCompleted.complete(Unit)
+        }
+        agentProtocol.setRequestHandler(TestMethod) { request ->
+            TestResponse(request.message)
+        }
+
+        agentProtocol.sendNotification(TestNotificationMethod, TestNotification("suspend"))
+        withTimeout(5_000) { notificationStarted.await() }
+
+        val requestJob = launch {
+            responseCompleted.complete(clientProtocol.sendRequest(TestMethod, TestRequest("response")))
+        }
+        val response = withTimeout(5_000) { responseCompleted.await() }
+
+        assertEquals("response", response.message)
+        assertTrue(!releaseNotification.isCompleted, "Notification handler should still be suspended")
+
+        releaseNotification.complete(Unit)
+        withTimeout(5_000) { notificationCompleted.await() }
+        requestJob.join()
+    }
+
+    @Test
+    fun `later notifications and requests progress while notification handler is suspended`() = testWithProtocols { clientProtocol, agentProtocol ->
+        val notificationStarted = CompletableDeferred<Unit>()
+        val releaseNotification = CompletableDeferred<Unit>()
+        val notificationCompleted = CompletableDeferred<Unit>()
+        val laterNotificationHandled = CompletableDeferred<Unit>()
+        val requestCompleted = CompletableDeferred<TestResponse>()
+
+        clientProtocol.setNotificationHandler(TestNotificationMethod) { notification ->
+            if (notification.message == "suspend") {
+                notificationStarted.complete(Unit)
+                releaseNotification.await()
+                notificationCompleted.complete(Unit)
+            } else {
+                laterNotificationHandled.complete(Unit)
+            }
+        }
+        clientProtocol.setRequestHandler(TestMethod) { request ->
+            TestResponse(request.message)
+        }
+
+        agentProtocol.sendNotification(TestNotificationMethod, TestNotification("suspend"))
+        withTimeout(5_000) { notificationStarted.await() }
+        agentProtocol.sendNotification(TestNotificationMethod, TestNotification("later"))
+
+        val requestJob = launch {
+            requestCompleted.complete(agentProtocol.sendRequest(TestMethod, TestRequest("request")))
+        }
+        val response = withTimeout(5_000) {
+            laterNotificationHandled.await()
+            requestCompleted.await()
+        }
+
+        assertEquals("request", response.message)
+        assertTrue(!releaseNotification.isCompleted, "First notification handler should still be suspended")
+
+        releaseNotification.complete(Unit)
+        withTimeout(5_000) { notificationCompleted.await() }
+        requestJob.join()
+    }
+
+    @Test
+    fun `cancel request notification progresses while notification handler is suspended`() = testWithProtocols { clientProtocol, agentProtocol ->
+        val notificationStarted = CompletableDeferred<Unit>()
+        val releaseNotification = CompletableDeferred<Unit>()
+        val notificationCompleted = CompletableDeferred<Unit>()
+        val requestStarted = CompletableDeferred<RequestId>()
+        val requestCancelled = CompletableDeferred<CancellationException>()
+
+        clientProtocol.setNotificationHandler(TestNotificationMethod) {
+            notificationStarted.complete(Unit)
+            releaseNotification.await()
+            notificationCompleted.complete(Unit)
+        }
+        clientProtocol.setRequestHandler(TestMethod) {
+            requestStarted.complete(currentCoroutineContext().jsonRpcRequest.id)
+            try {
+                awaitCancellation()
+            } catch (ce: CancellationException) {
+                requestCancelled.complete(ce)
+                throw ce
+            }
+        }
+
+        agentProtocol.sendNotification(TestNotificationMethod, TestNotification("suspend"))
+        withTimeout(5_000) { notificationStarted.await() }
+
+        val requestJob = launch {
+            agentProtocol.sendRequest(TestMethod, TestRequest("cancel"))
+        }
+        val requestId = withTimeout(5_000) { requestStarted.await() }
+        agentProtocol.sendNotification(
+            AcpMethod.MetaMethods.CancelRequest,
+            CancelRequestNotification(requestId, cancellationMessage)
+        )
+
+        val cancellationException = withTimeout(5_000) { requestCancelled.await() }
+        assertEquals(cancellationMessage, cancellationException.message)
+        assertTrue(!releaseNotification.isCompleted, "Notification handler should still be suspended")
+
+        releaseNotification.complete(Unit)
+        withTimeout(5_000) { notificationCompleted.await() }
+        agentProtocol.cancelPendingOutgoingRequests(CancellationException("Test request completed"))
+        requestJob.join()
+    }
+
+    @Test
+    fun `notification handler failure does not stop later protocol traffic`() = testWithProtocols { clientProtocol, agentProtocol ->
+        val failingNotificationStarted = CompletableDeferred<Unit>()
+        val laterNotificationHandled = CompletableDeferred<Unit>()
+        val requestCompleted = CompletableDeferred<TestResponse>()
+
+        clientProtocol.setNotificationHandler(TestNotificationMethod) { notification ->
+            if (notification.message == "fail") {
+                failingNotificationStarted.complete(Unit)
+                error("Notification handler failure")
+            } else {
+                laterNotificationHandled.complete(Unit)
+            }
+        }
+        clientProtocol.setRequestHandler(TestMethod) { request ->
+            TestResponse(request.message)
+        }
+
+        agentProtocol.sendNotification(TestNotificationMethod, TestNotification("fail"))
+        withTimeout(5_000) { failingNotificationStarted.await() }
+        agentProtocol.sendNotification(TestNotificationMethod, TestNotification("later"))
+
+        val requestJob = launch {
+            requestCompleted.complete(agentProtocol.sendRequest(TestMethod, TestRequest("request")))
+        }
+        val response = withTimeout(5_000) {
+            laterNotificationHandled.await()
+            requestCompleted.await()
+        }
+
+        assertEquals("request", response.message)
+        requestJob.join()
+    }
+
+    @Test
+    fun `closing protocol cancels suspended notification handler`() = testWithProtocols { clientProtocol, agentProtocol ->
+        val notificationStarted = CompletableDeferred<Unit>()
+        val notificationFinalized = CompletableDeferred<Unit>()
+
+        clientProtocol.setNotificationHandler(TestNotificationMethod) {
+            notificationStarted.complete(Unit)
+            try {
+                awaitCancellation()
+            } finally {
+                notificationFinalized.complete(Unit)
+            }
+        }
+
+        agentProtocol.sendNotification(TestNotificationMethod, TestNotification("suspend"))
+        withTimeout(5_000) { notificationStarted.await() }
+
+        clientProtocol.close()
+
+        withTimeout(5_000) { notificationFinalized.await() }
     }
 
 

--- a/acp-ktor-test/src/commonTest/kotlin/com/agentclientprotocol/ProtocolTest.kt
+++ b/acp-ktor-test/src/commonTest/kotlin/com/agentclientprotocol/ProtocolTest.kt
@@ -98,6 +98,44 @@ abstract class ProtocolTest(protocolDriver: ProtocolDriver) : ProtocolDriver by 
     }
 
     @Test
+    fun `non suspending notification is handled before later response`() = testWithProtocols { clientProtocol, agentProtocol ->
+        val notificationHandled = CompletableDeferred<Unit>()
+
+        clientProtocol.setNotificationHandler(TestNotificationMethod) {
+            notificationHandled.complete(Unit)
+        }
+        agentProtocol.setRequestHandler(TestMethod) { request ->
+            agentProtocol.sendNotification(TestNotificationMethod, TestNotification("before response"))
+            TestResponse(request.message)
+        }
+
+        val response = clientProtocol.sendRequest(TestMethod, TestRequest("response"))
+
+        assertEquals("response", response.message)
+        assertTrue(notificationHandled.isCompleted, "Notification should be handled before the later response")
+    }
+
+    @Test
+    fun `notification handler can await outgoing request`() = testWithProtocols { clientProtocol, agentProtocol ->
+        val notificationStarted = CompletableDeferred<Unit>()
+        val requestCompleted = CompletableDeferred<TestResponse>()
+
+        clientProtocol.setNotificationHandler(TestNotificationMethod) {
+            notificationStarted.complete(Unit)
+            requestCompleted.complete(clientProtocol.sendRequest(TestMethod, TestRequest("from notification")))
+        }
+        agentProtocol.setRequestHandler(TestMethod) { request ->
+            TestResponse(request.message)
+        }
+
+        agentProtocol.sendNotification(TestNotificationMethod, TestNotification("request"))
+
+        withTimeout(5_000) { notificationStarted.await() }
+        val response = withTimeout(5_000) { requestCompleted.await() }
+        assertEquals("from notification", response.message)
+    }
+
+    @Test
     fun `later notifications and requests progress while notification handler is suspended`() = testWithProtocols { clientProtocol, agentProtocol ->
         val notificationStarted = CompletableDeferred<Unit>()
         val releaseNotification = CompletableDeferred<Unit>()

--- a/acp/src/commonMain/kotlin/com/agentclientprotocol/protocol/Protocol.kt
+++ b/acp/src/commonMain/kotlin/com/agentclientprotocol/protocol/Protocol.kt
@@ -132,8 +132,8 @@ public class Protocol(
     public val options: ProtocolOptions = ProtocolOptions()
 ) : RpcMethodsOperations {
     private val scope = CoroutineScope(parentScope.coroutineContext + SupervisorJob(parentScope.coroutineContext[Job]) + CoroutineName(options.protocolDebugName))
-    // a scope and dispatcher that executes requests to avoid blocking of message processing
-    private val requestsScope = CoroutineScope(scope.coroutineContext + SupervisorJob(scope.coroutineContext[Job])
+    // a scope and dispatcher that executes handlers to avoid blocking of message processing
+    private val handlerScope = CoroutineScope(scope.coroutineContext + SupervisorJob(scope.coroutineContext[Job])
             + Dispatchers.Default.limitedParallelism(parallelism = 1) + CoroutineName(options.protocolDebugName))
     // now the incoming and outgoing requests can clash by ids, but it should not be a problem
     private val requestIdCounter: AtomicInt = atomic(0)
@@ -369,11 +369,13 @@ public class Protocol(
         runCatching {
             when (message) {
                 is JsonRpcNotification -> {
-                    handleNotification(message)
+                    handlerScope.launch {
+                        handleNotification(message)
+                    }
                 }
                 is JsonRpcRequest -> {
                     val requestId = IncomingRequestId(message.id)
-                    requestsScope.launch {
+                    handlerScope.launch {
                         handleRequest(message)
                     }.also { job ->
                         pendingIncomingRequests.update { map -> map.put(requestId, job) }

--- a/acp/src/commonMain/kotlin/com/agentclientprotocol/protocol/Protocol.kt
+++ b/acp/src/commonMain/kotlin/com/agentclientprotocol/protocol/Protocol.kt
@@ -132,9 +132,10 @@ public class Protocol(
     public val options: ProtocolOptions = ProtocolOptions()
 ) : RpcMethodsOperations {
     private val scope = CoroutineScope(parentScope.coroutineContext + SupervisorJob(parentScope.coroutineContext[Job]) + CoroutineName(options.protocolDebugName))
+    private val handlerDispatcher = Dispatchers.Default.limitedParallelism(parallelism = 1)
     // a scope and dispatcher that executes handlers to avoid blocking of message processing
     private val handlerScope = CoroutineScope(scope.coroutineContext + SupervisorJob(scope.coroutineContext[Job])
-            + Dispatchers.Default.limitedParallelism(parallelism = 1) + CoroutineName(options.protocolDebugName))
+            + handlerDispatcher + CoroutineName(options.protocolDebugName))
     // now the incoming and outgoing requests can clash by ids, but it should not be a problem
     private val requestIdCounter: AtomicInt = atomic(0)
     private val pendingOutgoingRequests: AtomicRef<PersistentMap<OutgoingRequestId, OutgoingRequest>> =
@@ -372,6 +373,7 @@ public class Protocol(
                     handlerScope.launch {
                         handleNotification(message)
                     }
+                    yieldToHandlerDispatcher()
                 }
                 is JsonRpcRequest -> {
                     val requestId = IncomingRequestId(message.id)
@@ -470,6 +472,11 @@ public class Protocol(
         } else {
             logger.debug { "No handler for notification: ${notification.method}" }
         }
+    }
+
+    private suspend fun yieldToHandlerDispatcher() {
+        // Preserve wire order for handlers that do not suspend without awaiting handlers that do.
+        withContext(handlerDispatcher) { Unit }
     }
 
     private fun handleResponse(response: JsonRpcResponse) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 private val buildNumber: String? = System.getenv("GITHUB_RUN_NUMBER")
 private val isReleasePublication = System.getenv("RELEASE_PUBLICATION")?.toBoolean() ?: false
 
-private val baseVersion = "0.28.1"
+private val baseVersion = "0.29.1"
 
 allprojects {
     group = "com.agentclientprotocol"


### PR DESCRIPTION
### Summary
- dispatch notification handlers through the protocol managed handler scope
- keep response handling on the reader path
- add deterministic concurrency, cancellation, failure-isolation, and shutdown regressions
- set the next release version to 0.29.1

### Verification
- `./gradlew :acp:jvmTest :acp-ktor-test:jvmTest --tests com.agentclientprotocol.StdioProtocolTest --tests com.agentclientprotocol.WebSocketProtocolTest`
- local full build reached iOS linking but was blocked by the local Xcode toolchain (`xcrun` exit 72)