### PR TITLE
Update version to 0.30.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 private val buildNumber: String? = System.getenv("GITHUB_RUN_NUMBER")
 private val isReleasePublication = System.getenv("RELEASE_PUBLICATION")?.toBoolean() ?: false
 
-private val baseVersion = "0.29.1"
+private val baseVersion = "0.30.1"
 
 allprojects {
     group = "com.agentclientprotocol"


### PR DESCRIPTION
Previous 0.30.0 release didn't update the actual artifact versions. Updating them now to a next patch version, skipping 0.30.0 to avoid confusion, because technically it was already released.