### PR TITLE
feat: add RFD session lifecycle events to v2

### DIFF
--- a/acp-model/api/acp-model.api
+++ b/acp-model/api/acp-model.api
@@ -8724,6 +8724,115 @@ public final class com/agentclientprotocol/model/v2/CloseSessionResponse$Compani
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public abstract class com/agentclientprotocol/model/v2/CompactionStatus {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/CompactionStatus$Companion;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/CompactionStatus$Cancelled : com/agentclientprotocol/model/v2/CompactionStatus {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/CompactionStatus$Cancelled;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/CompactionStatus$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/CompactionStatus$Completed : com/agentclientprotocol/model/v2/CompactionStatus {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/CompactionStatus$Completed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/CompactionStatus$Failed : com/agentclientprotocol/model/v2/CompactionStatus {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/CompactionStatus$Failed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/CompactionStatus$InProgress : com/agentclientprotocol/model/v2/CompactionStatus {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/CompactionStatus$InProgress;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/CompactionStatus$Unknown : com/agentclientprotocol/model/v2/CompactionStatus {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/CompactionStatus$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/CompactionStatus$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/CompactionStatus$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/CompactionSummaryChunk : com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/CompactionSummaryChunk$Companion;
+	public fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/ContentBlock;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/ContentBlock;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/agentclientprotocol/model/v2/ContentBlock;
+	public final fun component3 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/ContentBlock;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/CompactionSummaryChunk;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/CompactionSummaryChunk;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/ContentBlock;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/CompactionSummaryChunk;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCompactionId ()Ljava/lang/String;
+	public final fun getContent ()Lcom/agentclientprotocol/model/v2/ContentBlock;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/CompactionSummaryChunk$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/CompactionSummaryChunk$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/CompactionSummaryChunk;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/CompactionSummaryChunk;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/CompactionSummaryChunk$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/CompactionUpdate {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/CompactionUpdate$Companion;
+	public fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/CompactionStatus;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/CompactionStatus;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/agentclientprotocol/model/v2/CompactionStatus;
+	public final fun component3 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun component4 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun component5 ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun copy (Ljava/lang/String;Lcom/agentclientprotocol/model/v2/CompactionStatus;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;)Lcom/agentclientprotocol/model/v2/CompactionUpdate;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/CompactionUpdate;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/CompactionStatus;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;Lcom/agentclientprotocol/model/v2/MaybeUndefined;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/CompactionUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCompactionId ()Ljava/lang/String;
+	public final fun getError ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun getStatus ()Lcom/agentclientprotocol/model/v2/CompactionStatus;
+	public final fun getSummary ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public final fun get_meta ()Lcom/agentclientprotocol/model/v2/MaybeUndefined;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/CompactionUpdate$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/agentclientprotocol/model/v2/CompleteElicitationNotification : com/agentclientprotocol/model/AcpNotification {
 	public static final field Companion Lcom/agentclientprotocol/model/v2/CompleteElicitationNotification$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -11034,6 +11143,85 @@ public final class com/agentclientprotocol/model/v2/NewSessionResponse$Companion
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/agentclientprotocol/model/v2/Notice : com/agentclientprotocol/model/AcpWithMeta {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/Notice$Companion;
+	public fun <init> (Lcom/agentclientprotocol/model/v2/NoticeSeverity;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)V
+	public synthetic fun <init> (Lcom/agentclientprotocol/model/v2/NoticeSeverity;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/NoticeSeverity;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lkotlinx/serialization/json/JsonElement;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/NoticeSeverity;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;)Lcom/agentclientprotocol/model/v2/Notice;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/Notice;Lcom/agentclientprotocol/model/v2/NoticeSeverity;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/json/JsonElement;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/Notice;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getSeverity ()Lcom/agentclientprotocol/model/v2/NoticeSeverity;
+	public final fun getTitle ()Ljava/lang/String;
+	public fun get_meta ()Lkotlinx/serialization/json/JsonElement;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/agentclientprotocol/model/v2/Notice$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/Notice$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/agentclientprotocol/model/v2/Notice;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/agentclientprotocol/model/v2/Notice;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/Notice$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/agentclientprotocol/model/v2/NoticeSeverity {
+	public static final field Companion Lcom/agentclientprotocol/model/v2/NoticeSeverity$Companion;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/NoticeSeverity$Companion {
+	public final fun extension (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/NoticeSeverity$Unknown;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/agentclientprotocol/model/v2/NoticeSeverity$Error : com/agentclientprotocol/model/v2/NoticeSeverity {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/NoticeSeverity$Error;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/NoticeSeverity$Info : com/agentclientprotocol/model/v2/NoticeSeverity {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/NoticeSeverity$Info;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/NoticeSeverity$Unknown : com/agentclientprotocol/model/v2/NoticeSeverity {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/agentclientprotocol/model/v2/NoticeSeverity$Unknown;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/NoticeSeverity$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/NoticeSeverity$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/NoticeSeverity$Warning : com/agentclientprotocol/model/v2/NoticeSeverity {
+	public static final field INSTANCE Lcom/agentclientprotocol/model/v2/NoticeSeverity$Warning;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/agentclientprotocol/model/v2/PermissionOption : com/agentclientprotocol/model/AcpWithMeta {
 	public static final field Companion Lcom/agentclientprotocol/model/v2/PermissionOption$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/agentclientprotocol/model/v2/PermissionOptionKind;Lkotlinx/serialization/json/JsonElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -12518,6 +12706,28 @@ public final class com/agentclientprotocol/model/v2/SessionUpdate$AvailableComma
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/agentclientprotocol/model/v2/SessionUpdate$CompactionSummaryChunk : com/agentclientprotocol/model/v2/SessionUpdate {
+	public fun <init> (Lcom/agentclientprotocol/model/v2/CompactionSummaryChunk;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/CompactionSummaryChunk;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/CompactionSummaryChunk;)Lcom/agentclientprotocol/model/v2/SessionUpdate$CompactionSummaryChunk;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$CompactionSummaryChunk;Lcom/agentclientprotocol/model/v2/CompactionSummaryChunk;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$CompactionSummaryChunk;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChunk ()Lcom/agentclientprotocol/model/v2/CompactionSummaryChunk;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionUpdate$CompactionUpdate : com/agentclientprotocol/model/v2/SessionUpdate {
+	public fun <init> (Lcom/agentclientprotocol/model/v2/CompactionUpdate;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/CompactionUpdate;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/CompactionUpdate;)Lcom/agentclientprotocol/model/v2/SessionUpdate$CompactionUpdate;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$CompactionUpdate;Lcom/agentclientprotocol/model/v2/CompactionUpdate;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$CompactionUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUpdate ()Lcom/agentclientprotocol/model/v2/CompactionUpdate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/agentclientprotocol/model/v2/SessionUpdate$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
@@ -12529,6 +12739,17 @@ public final class com/agentclientprotocol/model/v2/SessionUpdate$ConfigOptionUp
 	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$ConfigOptionUpdate;Lcom/agentclientprotocol/model/v2/ConfigOptionUpdate;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$ConfigOptionUpdate;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getUpdate ()Lcom/agentclientprotocol/model/v2/ConfigOptionUpdate;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/agentclientprotocol/model/v2/SessionUpdate$Notice : com/agentclientprotocol/model/v2/SessionUpdate {
+	public fun <init> (Lcom/agentclientprotocol/model/v2/Notice;)V
+	public final fun component1 ()Lcom/agentclientprotocol/model/v2/Notice;
+	public final fun copy (Lcom/agentclientprotocol/model/v2/Notice;)Lcom/agentclientprotocol/model/v2/SessionUpdate$Notice;
+	public static synthetic fun copy$default (Lcom/agentclientprotocol/model/v2/SessionUpdate$Notice;Lcom/agentclientprotocol/model/v2/Notice;ILjava/lang/Object;)Lcom/agentclientprotocol/model/v2/SessionUpdate$Notice;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNotice ()Lcom/agentclientprotocol/model/v2/Notice;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/SessionUpdate.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/SessionUpdate.kt
@@ -39,6 +39,9 @@ import kotlinx.serialization.json.jsonObject
 @OptIn(UnstableApi::class) private typealias ConfigOptionUpdatePayload = ConfigOptionUpdate
 @OptIn(UnstableApi::class) private typealias SessionInfoUpdatePayload = SessionInfoUpdate
 @OptIn(UnstableApi::class) private typealias UsageUpdatePayload = UsageUpdate
+@OptIn(UnstableApi::class) private typealias NoticePayload = Notice
+@OptIn(UnstableApi::class) private typealias CompactionUpdatePayload = CompactionUpdate
+@OptIn(UnstableApi::class) private typealias CompactionSummaryChunkPayload = CompactionSummaryChunk
 
 /**
  * The input specification for a command.
@@ -463,6 +466,170 @@ internal object SessionInfoUpdateSerializer : KSerializer<SessionInfoUpdate> {
 }
 
 /**
+ * A live advisory notice from the agent.
+ *
+ * Notices are informational only: they MUST NOT carry information required for protocol
+ * correctness, authorization, user action, task completion, or fatal-error reporting.
+ * Clients may ignore them.
+ *
+ * See protocol docs: [Session Notices](https://agentclientprotocol.com/rfds/session-notices)
+ */
+@UnstableApi
+@Serializable
+public data class Notice(
+    val severity: NoticeSeverity,
+    val title: String,
+    val description: String? = null,
+    override val _meta: JsonElement? = null,
+) : AcpWithMeta
+
+/**
+ * Severity of a session notice.
+ *
+ * This is an open enum: unrecognized wire values deserialize to [Unknown] instead of
+ * failing, so newer ACP variants and `_`-prefixed extensions degrade gracefully.
+ */
+@UnstableApi
+@Serializable(with = NoticeSeveritySerializer::class)
+public sealed class NoticeSeverity {
+    public abstract val value: String
+
+    public data object Info : NoticeSeverity() { override val value: String = "info" }
+    public data object Warning : NoticeSeverity() { override val value: String = "warning" }
+    public data object Error : NoticeSeverity() { override val value: String = "error" }
+    public data class Unknown(override val value: String) : NoticeSeverity()
+
+    public companion object {
+        public fun extension(value: String): Unknown {
+            require(value.startsWith('_')) {
+                "Extension values must begin with '_'; values without the prefix are reserved for ACP (got '$value')"
+            }
+            return Unknown(value)
+        }
+    }
+}
+
+@OptIn(UnstableApi::class)
+internal object NoticeSeveritySerializer : OpenStringEnumSerializer<NoticeSeverity>(
+    serialName = "com.agentclientprotocol.model.v2.NoticeSeverity",
+    knownValues = listOf(NoticeSeverity.Info, NoticeSeverity.Warning, NoticeSeverity.Error),
+    wireValue = NoticeSeverity::value,
+    unknown = NoticeSeverity::Unknown,
+)
+
+/**
+ * A context compaction event.
+ *
+ * The first update for a [compactionId] fixes its timeline position. [summary], [error], and
+ * [_meta] have patch semantics: omission leaves the existing value unchanged, `null` clears
+ * it, and a concrete value replaces it.
+ *
+ * See protocol docs: [Session Compaction](https://agentclientprotocol.com/rfds/session-compaction)
+ */
+@UnstableApi
+@Serializable(with = CompactionUpdateSerializer::class)
+public data class CompactionUpdate(
+    val compactionId: String,
+    val status: CompactionStatus,
+    val summary: MaybeUndefined<List<ContentBlock>> = MaybeUndefined.Undefined,
+    val error: MaybeUndefined<String> = MaybeUndefined.Undefined,
+    val _meta: MaybeUndefined<JsonElement> = MaybeUndefined.Undefined,
+)
+
+@OptIn(UnstableApi::class)
+internal object CompactionUpdateSerializer : KSerializer<CompactionUpdate> {
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("com.agentclientprotocol.model.v2.CompactionUpdate")
+
+    override fun serialize(encoder: Encoder, value: CompactionUpdate) {
+        val jsonEncoder = encoder as JsonEncoder
+        val json = jsonEncoder.json
+        jsonEncoder.encodeJsonElement(
+            buildJsonObject {
+                put("compactionId", json.encodeToJsonElement(String.serializer(), value.compactionId))
+                put("status", json.encodeToJsonElement(CompactionStatus.serializer(), value.status))
+                putMaybeUndefined(json, "summary", value.summary, ListSerializer(ContentBlock.serializer()))
+                putMaybeUndefined(json, "error", value.error, String.serializer())
+                putMaybeUndefined(json, "_meta", value._meta, JsonElement.serializer())
+            }
+        )
+    }
+
+    override fun deserialize(decoder: Decoder): CompactionUpdate {
+        val jsonDecoder = decoder as JsonDecoder
+        val json = jsonDecoder.json
+        val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
+        val compactionId = jsonObject["compactionId"]
+            ?: throw SerializationException("Missing 'compactionId' in CompactionUpdate")
+        val status = jsonObject["status"]
+            ?: throw SerializationException("Missing 'status' in CompactionUpdate")
+        return CompactionUpdate(
+            compactionId = json.decodeFromJsonElement(String.serializer(), compactionId),
+            status = json.decodeFromJsonElement(CompactionStatus.serializer(), status),
+            summary = jsonObject.decodeMaybeUndefinedList(json, "summary", ContentBlock.serializer()),
+            error = jsonObject.decodeMaybeUndefined(json, "error", String.serializer()),
+            _meta = jsonObject.decodeMaybeUndefined(json, "_meta", JsonElement.serializer()),
+        )
+    }
+}
+
+/**
+ * Status of a context compaction operation.
+ *
+ * This is an open enum: unrecognized wire values deserialize to [Unknown] instead of
+ * failing, so newer ACP variants and `_`-prefixed extensions degrade gracefully.
+ */
+@UnstableApi
+@Serializable(with = CompactionStatusSerializer::class)
+public sealed class CompactionStatus {
+    public abstract val value: String
+
+    /** The compaction is currently running. */
+    public data object InProgress : CompactionStatus() { override val value: String = "in_progress" }
+
+    /** The compaction finished successfully. */
+    public data object Completed : CompactionStatus() { override val value: String = "completed" }
+
+    /** The compaction failed. */
+    public data object Failed : CompactionStatus() { override val value: String = "failed" }
+
+    /** The compaction was cancelled. */
+    public data object Cancelled : CompactionStatus() { override val value: String = "cancelled" }
+
+    public data class Unknown(override val value: String) : CompactionStatus()
+}
+
+@OptIn(UnstableApi::class)
+internal object CompactionStatusSerializer : OpenStringEnumSerializer<CompactionStatus>(
+    serialName = "com.agentclientprotocol.model.v2.CompactionStatus",
+    knownValues = listOf(
+        CompactionStatus.InProgress,
+        CompactionStatus.Completed,
+        CompactionStatus.Failed,
+        CompactionStatus.Cancelled,
+    ),
+    wireValue = CompactionStatus::value,
+    unknown = CompactionStatus::Unknown,
+)
+
+/**
+ * One [ContentBlock] appended to the compaction's retained summary.
+ *
+ * Summary chunks are only valid between the initial `in_progress` update and the terminal
+ * update for the same [compactionId]. A later [CompactionUpdate] with a concrete [CompactionUpdate.summary]
+ * replaces all accumulated chunk content.
+ *
+ * See protocol docs: [Session Compaction](https://agentclientprotocol.com/rfds/session-compaction)
+ */
+@UnstableApi
+@Serializable
+public data class CompactionSummaryChunk(
+    val compactionId: String,
+    val content: ContentBlock,
+    override val _meta: JsonElement? = null,
+) : AcpWithMeta
+
+/**
  * Different types of updates that can be sent during session processing.
  *
  * These updates provide real-time feedback about the agent's progress. Each variant wraps
@@ -625,6 +792,42 @@ public sealed class SessionUpdate {
     }
 
     /**
+     * A live advisory notice from the agent.
+     *
+     * Clients may ignore this update. It MUST NOT carry information required for protocol
+     * correctness or user action.
+     *
+     * See protocol docs: [Session Notices](https://agentclientprotocol.com/rfds/session-notices)
+     */
+    public data class Notice(val notice: NoticePayload) : SessionUpdate() {
+        internal companion object {
+            internal const val DISCRIMINATOR: String = "notice"
+        }
+    }
+
+    /**
+     * A context compaction event.
+     *
+     * See protocol docs: [Session Compaction](https://agentclientprotocol.com/rfds/session-compaction)
+     */
+    public data class CompactionUpdate(val update: CompactionUpdatePayload) : SessionUpdate() {
+        internal companion object {
+            internal const val DISCRIMINATOR: String = "compaction_update"
+        }
+    }
+
+    /**
+     * One content block appended to a compaction's retained summary.
+     *
+     * See protocol docs: [Session Compaction](https://agentclientprotocol.com/rfds/session-compaction)
+     */
+    public data class CompactionSummaryChunk(val chunk: CompactionSummaryChunkPayload) : SessionUpdate() {
+        internal companion object {
+            internal const val DISCRIMINATOR: String = "compaction_summary_chunk"
+        }
+    }
+
+    /**
      * Custom or future session update.
      *
      * [rawJson] holds the complete payload as received (including the discriminator), so
@@ -728,6 +931,18 @@ internal object SessionUpdateSerializer : OpenTaggedUnionSerializer<SessionUpdat
             "UsageUpdate", UsageUpdatePayload.serializer(),
             SessionUpdate::UsageUpdate, SessionUpdate.UsageUpdate::update,
         ),
+        SessionUpdate.Notice.DISCRIMINATOR to SessionUpdateVariantSerializer(
+            "Notice", NoticePayload.serializer(),
+            SessionUpdate::Notice, SessionUpdate.Notice::notice,
+        ),
+        SessionUpdate.CompactionUpdate.DISCRIMINATOR to SessionUpdateVariantSerializer(
+            "CompactionUpdate", CompactionUpdatePayload.serializer(),
+            SessionUpdate::CompactionUpdate, SessionUpdate.CompactionUpdate::update,
+        ),
+        SessionUpdate.CompactionSummaryChunk.DISCRIMINATOR to SessionUpdateVariantSerializer(
+            "CompactionSummaryChunk", CompactionSummaryChunkPayload.serializer(),
+            SessionUpdate::CompactionSummaryChunk, SessionUpdate.CompactionSummaryChunk::chunk,
+        ),
     ),
     discriminator = { value ->
         when (value) {
@@ -746,6 +961,9 @@ internal object SessionUpdateSerializer : OpenTaggedUnionSerializer<SessionUpdat
             is SessionUpdate.ConfigOptionUpdate -> SessionUpdate.ConfigOptionUpdate.DISCRIMINATOR
             is SessionUpdate.SessionInfoUpdate -> SessionUpdate.SessionInfoUpdate.DISCRIMINATOR
             is SessionUpdate.UsageUpdate -> SessionUpdate.UsageUpdate.DISCRIMINATOR
+            is SessionUpdate.Notice -> SessionUpdate.Notice.DISCRIMINATOR
+            is SessionUpdate.CompactionUpdate -> SessionUpdate.CompactionUpdate.DISCRIMINATOR
+            is SessionUpdate.CompactionSummaryChunk -> SessionUpdate.CompactionSummaryChunk.DISCRIMINATOR
             is SessionUpdate.Unknown -> value.sessionUpdate
         }
     },

--- a/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/SessionUpdateConversions.kt
+++ b/acp-model/src/commonMain/kotlin/com/agentclientprotocol/model/v2/conversion/SessionUpdateConversions.kt
@@ -273,6 +273,19 @@ public fun SessionUpdate.toV1(): List<V1SessionUpdate> = when (this) {
     is SessionUpdate.ConfigOptionUpdate -> listOf(update.toV1())
     is SessionUpdate.SessionInfoUpdate -> listOf(update.toV1())
     is SessionUpdate.UsageUpdate -> listOf(update.toV1())
+
+    is SessionUpdate.Notice -> throw ProtocolConversionException(
+        "v2 SessionUpdate variant `notice` cannot be represented in v1"
+    )
+
+    is SessionUpdate.CompactionUpdate -> throw ProtocolConversionException(
+        "v2 SessionUpdate variant `compaction_update` cannot be represented in v1"
+    )
+
+    is SessionUpdate.CompactionSummaryChunk -> throw ProtocolConversionException(
+        "v2 SessionUpdate variant `compaction_summary_chunk` cannot be represented in v1"
+    )
+
     is SessionUpdate.Unknown -> throw unknownV2EnumVariant("SessionUpdate", sessionUpdate)
 }
 

--- a/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/SessionNoticeAndCompactionTest.kt
+++ b/acp-model/src/commonTest/kotlin/com/agentclientprotocol/model/v2/SessionNoticeAndCompactionTest.kt
@@ -1,0 +1,298 @@
+@file:OptIn(UnstableApi::class)
+
+package com.agentclientprotocol.model.v2
+
+import com.agentclientprotocol.annotations.UnstableApi
+import com.agentclientprotocol.rpc.ACPJson
+import kotlinx.serialization.SerializationException
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SessionNoticeAndCompactionTest {
+
+    // --- Notice ---
+
+    @Test
+    fun `decodes notice with warning severity`() {
+        val json = """{"severity":"warning","title":"MCP server unavailable","description":"Continuing without it."}"""
+        val notice = ACPJson.decodeFromString(Notice.serializer(), json)
+        assertEquals(NoticeSeverity.Warning, notice.severity)
+        assertEquals("MCP server unavailable", notice.title)
+        assertEquals("Continuing without it.", notice.description)
+        assertNull(notice._meta)
+    }
+
+    @Test
+    fun `decodes notice without optional fields`() {
+        val json = """{"severity":"info","title":"Indexing started"}"""
+        val notice = ACPJson.decodeFromString(Notice.serializer(), json)
+        assertEquals(NoticeSeverity.Info, notice.severity)
+        assertEquals("Indexing started", notice.title)
+        assertNull(notice.description)
+    }
+
+    @Test
+    fun `decodes notice with error severity`() {
+        val json = """{"severity":"error","title":"Provider failed","description":"Retrying."}"""
+        val notice = ACPJson.decodeFromString(Notice.serializer(), json)
+        assertEquals(NoticeSeverity.Error, notice.severity)
+    }
+
+    @Test
+    fun `decodes notice with unknown severity`() {
+        val json = """{"severity":"_custom","title":"Custom notice"}"""
+        val notice = ACPJson.decodeFromString(Notice.serializer(), json)
+        assertIs<NoticeSeverity.Unknown>(notice.severity)
+        assertEquals("_custom", notice.severity.value)
+    }
+
+    @Test
+    fun `round-trips notice as session update`() {
+        val original = SessionUpdate.Notice(
+            Notice(severity = NoticeSeverity.Warning, title = "Low memory", description = "Consider closing tabs.")
+        )
+        val encoded = ACPJson.encodeToString(SessionUpdate.serializer(), original)
+        assertContains(encoded, "\"sessionUpdate\":\"notice\"")
+        assertContains(encoded, "\"severity\":\"warning\"")
+        assertContains(encoded, "\"title\":\"Low memory\"")
+
+        val decoded = ACPJson.decodeFromString(SessionUpdate.serializer(), encoded)
+        assertIs<SessionUpdate.Notice>(decoded)
+        assertEquals("Low memory", decoded.notice.title)
+        assertEquals(NoticeSeverity.Warning, decoded.notice.severity)
+    }
+
+    @Test
+    fun `decodes notice session update from json`() {
+        val json = """{
+            "sessionUpdate": "notice",
+            "severity": "info",
+            "title": "Sync complete",
+            "description": "All files are up to date."
+        }"""
+        val update = ACPJson.decodeFromString(SessionUpdate.serializer(), json)
+        assertIs<SessionUpdate.Notice>(update)
+        assertEquals(NoticeSeverity.Info, update.notice.severity)
+        assertEquals("Sync complete", update.notice.title)
+        assertEquals("All files are up to date.", update.notice.description)
+    }
+
+    // --- NoticeSeverity open enum ---
+
+    @Test
+    fun `NoticeSeverity extension value must start with underscore`() {
+        assertFailsWith<IllegalArgumentException> {
+            NoticeSeverity.extension("customValue")
+        }
+    }
+
+    @Test
+    fun `NoticeSeverity extension value with underscore is accepted`() {
+        val ext = NoticeSeverity.extension("_myCustomSeverity")
+        assertIs<NoticeSeverity.Unknown>(ext)
+        assertEquals("_myCustomSeverity", ext.value)
+    }
+
+    // --- CompactionStatus open enum ---
+
+    @Test
+    fun `decodes all known CompactionStatus values`() {
+        assertEquals(CompactionStatus.InProgress, decodeStatus("in_progress"))
+        assertEquals(CompactionStatus.Completed, decodeStatus("completed"))
+        assertEquals(CompactionStatus.Failed, decodeStatus("failed"))
+        assertEquals(CompactionStatus.Cancelled, decodeStatus("cancelled"))
+    }
+
+    @Test
+    fun `decodes unknown CompactionStatus as Unknown`() {
+        val status = decodeStatus("_experimental")
+        assertIs<CompactionStatus.Unknown>(status)
+        assertEquals("_experimental", status.value)
+    }
+
+    private fun decodeStatus(value: String): CompactionStatus =
+        ACPJson.decodeFromString(CompactionStatus.serializer(), "\"$value\"")
+
+    // --- CompactionUpdate ---
+
+    @Test
+    fun `decodes compaction_update with in_progress status`() {
+        val json = """{"compactionId":"cmp_001","status":"in_progress"}"""
+        val update = ACPJson.decodeFromString(CompactionUpdate.serializer(), json)
+        assertEquals("cmp_001", update.compactionId)
+        assertEquals(CompactionStatus.InProgress, update.status)
+        assertEquals(MaybeUndefined.Undefined, update.summary)
+        assertEquals(MaybeUndefined.Undefined, update.error)
+        assertEquals(MaybeUndefined.Undefined, update._meta)
+    }
+
+    @Test
+    fun `decodes compaction_update with completed status and summary`() {
+        val json = """{
+            "compactionId": "cmp_001",
+            "status": "completed",
+            "summary": [{"type": "text", "text": "Kept 3 messages."}]
+        }"""
+        val update = ACPJson.decodeFromString(CompactionUpdate.serializer(), json)
+        assertEquals(CompactionStatus.Completed, update.status)
+        assertIs<MaybeUndefined.Value<List<ContentBlock>>>(update.summary)
+        val summary = (update.summary as MaybeUndefined.Value).value
+        assertEquals(1, summary.size)
+        assertEquals("Kept 3 messages.", (summary[0] as ContentBlock.Text).text)
+    }
+
+    @Test
+    fun `decodes compaction_update with null summary as Null`() {
+        val json = """{"compactionId":"cmp_001","status":"completed","summary":null}"""
+        val update = ACPJson.decodeFromString(CompactionUpdate.serializer(), json)
+        assertEquals(MaybeUndefined.Null, update.summary)
+    }
+
+    @Test
+    fun `decodes compaction_update with error`() {
+        val json = """{"compactionId":"cmp_002","status":"failed","error":"Context limit exceeded"}"""
+        val update = ACPJson.decodeFromString(CompactionUpdate.serializer(), json)
+        assertEquals(CompactionStatus.Failed, update.status)
+        assertIs<MaybeUndefined.Value<String>>(update.error)
+        assertEquals("Context limit exceeded", (update.error as MaybeUndefined.Value).value)
+    }
+
+    @Test
+    fun `round-trips compaction_update as session update`() {
+        val original = SessionUpdate.CompactionUpdate(
+            CompactionUpdate(compactionId = "cmp_42", status = CompactionStatus.InProgress)
+        )
+        val encoded = ACPJson.encodeToString(SessionUpdate.serializer(), original)
+        assertContains(encoded, "\"sessionUpdate\":\"compaction_update\"")
+        assertContains(encoded, "\"compactionId\":\"cmp_42\"")
+        assertContains(encoded, "\"status\":\"in_progress\"")
+        assertTrue(!encoded.contains("summary"))
+        assertTrue(!encoded.contains("error"))
+
+        val decoded = ACPJson.decodeFromString(SessionUpdate.serializer(), encoded)
+        assertIs<SessionUpdate.CompactionUpdate>(decoded)
+        assertEquals("cmp_42", decoded.update.compactionId)
+        assertEquals(CompactionStatus.InProgress, decoded.update.status)
+    }
+
+    @Test
+    fun `decodes compaction_update session update from json`() {
+        val json = """{
+            "sessionUpdate": "compaction_update",
+            "compactionId": "cmp_001",
+            "status": "in_progress"
+        }"""
+        val update = ACPJson.decodeFromString(SessionUpdate.serializer(), json)
+        assertIs<SessionUpdate.CompactionUpdate>(update)
+        assertEquals("cmp_001", update.update.compactionId)
+        assertEquals(CompactionStatus.InProgress, update.update.status)
+    }
+
+    @Test
+    fun `serializes compaction_update omitting undefined patch fields`() {
+        val compactionUpdate = CompactionUpdate(
+            compactionId = "cmp_1",
+            status = CompactionStatus.Completed,
+            summary = MaybeUndefined.Value(listOf(ContentBlock.Text("Summary text"))),
+        )
+        val encoded = ACPJson.encodeToString(CompactionUpdate.serializer(), compactionUpdate)
+        assertContains(encoded, "\"summary\"")
+        assertTrue(!encoded.contains("\"error\""))
+    }
+
+    @Test
+    fun `serializes compaction_update with null error as explicit null`() {
+        val compactionUpdate = CompactionUpdate(
+            compactionId = "cmp_1",
+            status = CompactionStatus.Failed,
+            error = MaybeUndefined.Null,
+        )
+        val encoded = ACPJson.encodeToString(CompactionUpdate.serializer(), compactionUpdate)
+        assertContains(encoded, "\"error\":null")
+    }
+
+    @Test
+    fun `throws on missing compactionId`() {
+        val json = """{"status":"in_progress"}"""
+        assertFailsWith<SerializationException> {
+            ACPJson.decodeFromString(CompactionUpdate.serializer(), json)
+        }
+    }
+
+    @Test
+    fun `throws on missing status`() {
+        val json = """{"compactionId":"cmp_1"}"""
+        assertFailsWith<SerializationException> {
+            ACPJson.decodeFromString(CompactionUpdate.serializer(), json)
+        }
+    }
+
+    // --- CompactionSummaryChunk ---
+
+    @Test
+    fun `decodes compaction_summary_chunk`() {
+        val json = """{"compactionId":"cmp_001","content":{"type":"text","text":"Condensed history."}}"""
+        val chunk = ACPJson.decodeFromString(CompactionSummaryChunk.serializer(), json)
+        assertEquals("cmp_001", chunk.compactionId)
+        assertEquals("Condensed history.", (chunk.content as ContentBlock.Text).text)
+        assertNull(chunk._meta)
+    }
+
+    @Test
+    fun `round-trips compaction_summary_chunk as session update`() {
+        val original = SessionUpdate.CompactionSummaryChunk(
+            CompactionSummaryChunk(
+                compactionId = "cmp_001",
+                content = ContentBlock.Text("Retained context."),
+            )
+        )
+        val encoded = ACPJson.encodeToString(SessionUpdate.serializer(), original)
+        assertContains(encoded, "\"sessionUpdate\":\"compaction_summary_chunk\"")
+        assertContains(encoded, "\"compactionId\":\"cmp_001\"")
+
+        val decoded = ACPJson.decodeFromString(SessionUpdate.serializer(), encoded)
+        assertIs<SessionUpdate.CompactionSummaryChunk>(decoded)
+        assertEquals("cmp_001", decoded.chunk.compactionId)
+        assertEquals("Retained context.", (decoded.chunk.content as ContentBlock.Text).text)
+    }
+
+    @Test
+    fun `decodes compaction_summary_chunk session update from json`() {
+        val json = """{
+            "sessionUpdate": "compaction_summary_chunk",
+            "compactionId": "cmp_001",
+            "content": {"type": "text", "text": "Kept the last 5 exchanges."}
+        }"""
+        val update = ACPJson.decodeFromString(SessionUpdate.serializer(), json)
+        assertIs<SessionUpdate.CompactionSummaryChunk>(update)
+        assertEquals("cmp_001", update.chunk.compactionId)
+        assertEquals("Kept the last 5 exchanges.", (update.chunk.content as ContentBlock.Text).text)
+    }
+
+    // --- full lifecycle sequence ---
+
+    @Test
+    fun `decodes a compaction lifecycle sequence`() {
+        val updates = listOf(
+            """{"sessionUpdate":"compaction_update","compactionId":"cmp_1","status":"in_progress"}""",
+            """{"sessionUpdate":"compaction_summary_chunk","compactionId":"cmp_1","content":{"type":"text","text":"Chunk 1"}}""",
+            """{"sessionUpdate":"compaction_summary_chunk","compactionId":"cmp_1","content":{"type":"text","text":"Chunk 2"}}""",
+            """{"sessionUpdate":"compaction_update","compactionId":"cmp_1","status":"completed","summary":[{"type":"text","text":"Final summary"}]}""",
+        ).map { ACPJson.decodeFromString(SessionUpdate.serializer(), it) }
+
+        assertIs<SessionUpdate.CompactionUpdate>(updates[0])
+        assertIs<SessionUpdate.CompactionSummaryChunk>(updates[1])
+        assertIs<SessionUpdate.CompactionSummaryChunk>(updates[2])
+        assertIs<SessionUpdate.CompactionUpdate>(updates[3])
+
+        val terminal = updates[3] as SessionUpdate.CompactionUpdate
+        assertEquals(CompactionStatus.Completed, terminal.update.status)
+        val summary = (terminal.update.summary as MaybeUndefined.Value).value
+        assertEquals("Final summary", (summary[0] as ContentBlock.Text).text)
+    }
+}


### PR DESCRIPTION
## Description

Current version of `v2` implementation is already compliant with ACP v2 session lifecycle. Added missing parts - session update events proposed in RFDs:
* `SessionUpdate.Notice`
* `SessionUpdate.CompactionUpdate`
* `SessionUpdate.CompactionSummaryChunk`

## Note
Even though RFDs propose to add these events both to v1 and v2, I decided not to touch v1 implementation to avoid any major changes there